### PR TITLE
add wheel to requirements for python 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pytest-metadata==1.7.0
 pytest==3.7.0
 python-dateutil==2.7.3
 git+https://github.com/hwine/python-herokuadmintools.git#egg=herokuadmintools
+wheel==0.31.1


### PR DESCRIPTION
this should fix the "error: invalid command 'bdist_wheel'" errors we're seeing