### PR TITLE
Include InstanceId in pytest metadata

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -140,6 +140,7 @@ METADATA_KEYS = [
     "DBInstanceIdentifier",
     "GroupId",
     "ImageId",
+    "InstanceId",
     "LaunchTime",
     "OwnerId",
     "TagList",


### PR DESCRIPTION
Include `InstanceId` in pytest results metadata.

The instance id tends to already be present as the "id" of the test, but this will make extracting it easier in a lot of cases.