### PR TITLE
Test for ELB with 0 instances attached

### DIFF
--- a/aws/elb/test_elb_instances_attached.py
+++ b/aws/elb/test_elb_instances_attached.py
@@ -1,0 +1,14 @@
+import pytest
+
+from aws.elb.resources import elbs
+
+@pytest.mark.elb
+@pytest.mark.parametrize(
+    "elb", elbs(), ids=lambda e: e["LoadBalancerName"],
+)
+def test_elb_instances_attached(elb):
+    """
+    Checks to see that an ELB has attached instances and fails if
+    there are 0
+    """
+    assert len(elb["Instances"]) > 0, "ELB has zero attached instances"


### PR DESCRIPTION
Checks whether an ELB (v1) has any instances attached and fails if there are none. Similar to our "security group in use" test.