### PR TITLE
Fix 302 add cli bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ AWS_PROFILE := default
 PYTEST_OPTS := ''
 
 all: check_venv
-	pytest
+	frost test
 
 awsci: check_venv
-	pytest --continue-on-collection-errors aws/ \
+	frost test --continue-on-collection-errors aws/ \
 		--ignore aws/ec2/test_ec2_security_group_in_use.py \
 		--json=results-$(AWS_PROFILE)-$(TODAY).json $(PYTEST_OPTS)
 
@@ -30,7 +30,7 @@ clean: clean-cache clean-python
 
 clean-cache: check_venv
 	@# do as little work as possible to clear the cache, and guarantee success
-	pytest --cache-clear --continue-on-collection-errors \
+	frost test  --cache-clear --continue-on-collection-errors \
 		--collect-only -m "no_such_marker" \
 		--noconftest --tb=no --disable-warnings --quiet \
 	    || true
@@ -39,10 +39,10 @@ clean-python:
 	find . -type d -name venv -prune -o -type d -name __pycache__ -print0 | xargs -0 rm -rf
 
 doctest: check_venv
-	pytest --doctest-modules -s --offline --debug-calls --ignore pagerduty/
+	frost test --doctest-modules -s --offline --debug-calls --ignore pagerduty/
 
 coverage: check_venv
-	pytest --cov-config .coveragerc --cov=. \
+	frost test --cov-config .coveragerc --cov=. \
 		--aws-profiles example-account \
 		-o python_files=meta_test*.py \
 		-o cache_dir=./example_cache/
@@ -62,7 +62,7 @@ setup_gsuite: check_venv
 	python -m bin.auth.setup_gsuite
 
 metatest:
-	pytest --aws-profiles example-account \
+	frost test --aws-profiles example-account \
 		-o python_files=meta_test*.py \
 		-o cache_dir=./example_cache/
 

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ all: check_venv
 	frost test
 
 awsci: check_venv
-	frost test --continue-on-collection-errors aws/ \
-		--ignore aws/ec2/test_ec2_security_group_in_use.py \
+	frost test --continue-on-collection-errors -m aws \
+		-k "not test_ec2_security_group_in_use" \
 		--json=results-$(AWS_PROFILE)-$(TODAY).json $(PYTEST_OPTS)
 
 check_venv:

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ black: check_venv
 	pre-commit run black --all-files
 
 install: venv
-	( . venv/bin/activate && pip install -U pip && pip install -r requirements.txt  && pre-commit install )
+	( . venv/bin/activate && pip install -U pip && pip install -r requirements.txt && python setup.py develop && pre-commit install )
 
 setup_gsuite: check_venv
 	python -m bin.auth.setup_gsuite

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Frost
 
-Clients and [pytest](https://docs.pytest.org/en/latest/index.html)
-tests for checking that third party services the @foxsec team uses are
-configured correctly.
+[![PyPI version](https://badge.fury.io/py/frost.svg)](https://badge.fury.io/py/frost)
 
-We trust third party services to return their status correctly, but
-want to answer questions whether they are configured properly such as:
+Frost (for FiRefox Operations Security Testing) is a set of API
+clients, [pytest](https://docs.pytest.org/en/latest/index.html) tests
+to verify the configuration of third party services. For example:
 
 * Are our AWS DB snapshots publicly accessible?
 * Is there a dangling DNS entry in Route53?

--- a/README.md
+++ b/README.md
@@ -14,10 +14,7 @@ to verify the configuration of third party services. For example:
 
 ### Requirements
 
-* [GNU Make 3.81](https://www.gnu.org/software/make/)
-* [Python 3.6.2](https://www.python.org/downloads/)
-
-Note: other versions may work too these are the versions @g-k used for development
+* [Python 3.8](https://www.python.org/downloads/)
 
 ### Installing
 

--- a/README.md
+++ b/README.md
@@ -691,10 +691,10 @@ Notes:
 * we add markers for the services we're fetching data from
 
 
-1. Running it we see that one of the IPs is an AWS IP:
+1. Running `frost test` with the test file explicitly included we see that one of the IPs is an AWS IP:
 
 ```console
-pytest --ignore aws/
+frost test ./httpbin/test_httpbin_ip.py
 platform darwin -- Python 3.6.2, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
 metadata: {'Python': '3.6.2', 'Platform': 'Darwin-15.6.0-x86_64-i386-64bit', 'Packages': {'pytest': '3.3.2', 'py': '1.5.2', 'pluggy': '0.6.0'}, 'Plugins': {'metadata': '1.5.1', 'json': '0.4.0', 'html': '1.16.1'}}
 rootdir: /Users/gguthe/frost, inifile:

--- a/README.md
+++ b/README.md
@@ -18,24 +18,35 @@ to verify the configuration of third party services. For example:
 
 ### Installing
 
-From the project root run:
-
 ```console
-make install
+pip install frost
 ```
 
-This will:
+### Usage
 
-* create a Python [virtualenv](https://docs.python.org/3/library/venv.html) to isolate it from other Python packages
-* install Python requirements in the virtualenv
+```console
+$ frost --help
+Usage: frost [OPTIONS] COMMAND [ARGS]...
+
+  FiRefox Operations Security Testing API clients and tests
+
+Options:
+  --version  Show the version and exit.
+  --help     Show this message and exit.
+
+  Commands:
+    test  Run pytest tests passing all trailing args to pytest.
+
+$ frost test --help
+Usage: frost test [OPTIONS] [PYTEST_ARGS]...
+
+  Run pytest tests passing all trailing args to pytest.
+
+Options:
+  --help  Show this message and exit.
+```
 
 ### Running
-
-Activate the venv in the project root:
-
-```console
-source venv/bin/activate
-```
 
 To fetch RDS resources from the cache or AWS API and check that
 backups are enabled for DB instances for [the configured aws
@@ -43,22 +54,21 @@ profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html)
 named `default` in the `us-west-2` region we can run:
 
 ```console
-pytest --ignore aws/s3 --ignore aws/ec2 -k test_rds_db_instance_backup_enabled -s --aws-profiles default --debug-calls
+frost test -k test_rds_db_instance_backup_enabled --aws-profiles default --debug-calls
 ```
 
-The options include pytest options:
-
-* [`--ignore`](https://docs.pytest.org/en/latest/example/pythoncollection.html#ignore-paths-during-test-collection) to skip fetching resources for non-RDS resources
-* [`-k`](https://docs.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name) for selecting tests matching the substring `test_rds_db_instance_backup_enabled` for the one test we want to run
-* [`-m`](https://docs.pytest.org/en/latest/example/markers.html#marking-test-functions-and-selecting-them-for-a-run) not used but the marker filter can be useful for selecting all tests for specific services (e.g. `-m rds`)
-* [`-s`](https://docs.pytest.org/en/latest/capture.html) to disable capturing stdout so we can see the progress fetching AWS resources
-
-and options frost adds:
+frost switches to its package directory and adds pytest options:
 
 * `--debug-calls` for printing (with `-s`) API calls we make
 * `--aws-profiles` for selecting one or more AWS profiles to fetch resources for or the AWS default profile / `AWS_PROFILE` environment variable
 * `--offline` a flag to tell HTTP clients to not make requests and return empty params
 * [`--config`](#custom-test-config) path to test custom config file
+
+which can be combined with the standard pytest options for selecting frost tests and other local tests:
+
+* [`-k`](https://docs.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name) to select the test matching the substring `test_rds_db_instance_backup_enabled`
+* [`-m`](https://docs.pytest.org/en/latest/example/markers.html#marking-test-functions-and-selecting-them-for-a-run) not used but the marker filter can be useful for selecting all tests for specific services (e.g. `-m rds`)
+* [`-s`](https://docs.pytest.org/en/latest/capture.html) to disable capturing stdout so we can see the progress fetching AWS resources
 
 and produces output like the following showing a DB instance with backups disabled:
 
@@ -67,7 +77,7 @@ and produces output like the following showing a DB instance with backups disabl
 platform darwin -- Python 3.6.2, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
 metadata: {'Python': '3.6.2', 'Platform': 'Darwin-15.6.0-x86_64-i386-64bit', 'Packages': {'pytest': '3.3.2', 'py': '1.5.2', 'pluggy': '0.6.
 0'}, 'Plugins': {'metadata': '1.5.1', 'json': '0.4.0', 'html': '1.16.1'}}
-rootdir: /Users/gguthe/mozilla/frost, inifile:
+rootdir: /Users/gguthe/frost, inifile:
 plugins: metadata-1.5.1, json-0.4.0, html-1.16.1
 collecting 0 items                                                                                                                        c
 alling AWSAPICall(profile='default', region='us-west-2', service='rds', method='describe_db_instances', args=[], kwargs={})
@@ -357,7 +367,7 @@ And results in a severity and severity marker being included in the
 json metadata:
 
 ```console
-pytest --ignore aws/s3 --ignore aws/rds --ignore aws/iam -s --aws-profiles stage --aws-require-tags Name Type App Stack -k test_ec2_instance_has_required_tags --config config.yaml.example --json=report.json
+frost -s --aws-profiles stage --aws-require-tags Name Type App Stack -k test_ec2_instance_has_required_tags --config config.yaml.example --json=report.json
 ...
 ```
 
@@ -687,7 +697,7 @@ Notes:
 pytest --ignore aws/
 platform darwin -- Python 3.6.2, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
 metadata: {'Python': '3.6.2', 'Platform': 'Darwin-15.6.0-x86_64-i386-64bit', 'Packages': {'pytest': '3.3.2', 'py': '1.5.2', 'pluggy': '0.6.0'}, 'Plugins': {'metadata': '1.5.1', 'json': '0.4.0', 'html': '1.16.1'}}
-rootdir: /Users/gguthe/mozilla/frost, inifile:
+rootdir: /Users/gguthe/frost, inifile:
 plugins: metadata-1.5.1, json-0.4.0, html-1.16.1
 collected 3 items
 

--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,7 @@ from heroku.client import HerokuAdminClient
 
 import custom_config
 
+collect_ignore_glob = "*"
 
 botocore_client = None
 gcp_client = None

--- a/frost/__init__.py
+++ b/frost/__init__.py
@@ -1,0 +1,2 @@
+SOURCE_URL = "https://github.com/mozilla/frost"
+VERSION = "0.3.1"

--- a/frost/__init__.py
+++ b/frost/__init__.py
@@ -1,2 +1,2 @@
 SOURCE_URL = "https://github.com/mozilla/frost"
-VERSION = "0.3.1"
+VERSION = "0.4.0"

--- a/frost/cli.py
+++ b/frost/cli.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 import click
@@ -20,6 +21,9 @@ def test(ctx, pytest_args):
     """
     Run pytest tests passing all trailing args to pytest.
     """
+    # look up frost/.. to get the repo root dir
+    frost_parent_directory = os.path.dirname(os.path.dirname(__file__))
+    os.chdir(frost_parent_directory)
     pytest.main(list(pytest_args))
 
 

--- a/frost/cli.py
+++ b/frost/cli.py
@@ -1,0 +1,27 @@
+import sys
+
+import click
+import pytest
+
+
+@click.group()
+@click.version_option()
+def cli():
+    """
+    FiRefox Operations Security Testing API clients and tests
+    """
+    pass
+
+
+@cli.command(context_settings=dict(ignore_unknown_options=True,))
+@click.argument("pytest_args", nargs=-1, type=click.UNPROCESSED)
+@click.pass_context
+def test(ctx, pytest_args):
+    """
+    Run pytest tests passing all trailing args to pytest.
+    """
+    pytest.main(list(pytest_args))
+
+
+if __name__ == "__main__":
+    cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 botocore==1.12.75
+click==7.1.2
 coverage==4.5.3
 google_api_python_client==1.6.1
 pytest-cov==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import setuptools
 
 with open("README.md", "r") as fh:

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python
 
 import setuptools
+from frost import SOURCE_URL, VERSION
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="frost",
-    version="0.3.1",
+    version=VERSION,
     author="Firefox Operations Security Team (foxsec)",
     author_email="foxsec+frost@mozilla.com",
     description="tests for checking that third party services the Firefox Operations Security or foxsec team uses are configured correctly",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/mozilla/frost",
+    url=SOURCE_URL,
     license="MPL2",
     packages=setuptools.find_packages(),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,5 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
     ],
     python_requires=">=3.8",
+    entry_points={"console_scripts": ["frost=frost.cli:cli"],},
 )

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ setuptools.setup(
         "Natural Language :: English",
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
fixes #302 

Changes:

* add a `frost` python module in `/frost`
* add a `frost` console script to the python package with subcommand `test` that runs pytest in the repo root (to pick up frost tests)
* bump version to 0.4.0
* default to ignoring and not collecting all tests (so `--ignore` is not required) 
* TODO: add way to list tests for selection via CLI 