### PR TITLE
Test on multiple versions of python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,3 @@ repos:
     rev: 19.10b0
     hooks:
     - id: black
-      language_version: python3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python:
+  - "3.6"
+  - "3.7"
   - "3.8"
 sudo: required
 


### PR DESCRIPTION
Run on Python 3.6+ in CI. Don't specify python version in pre-commit config.

Related to #304, #305, #306 