### PR TITLE
cache: remove PY2 import from pytest internals

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -7,7 +7,6 @@ import functools
 import json
 
 import py
-from _pytest.compat import _PY2 as PY2
 from dateutil.parser import parse
 
 
@@ -52,7 +51,7 @@ def datetime_encode_set(self, key, value):
         self.warn("could not create cache path {path}", path=path)
         return
     try:
-        f = path.open("wb" if PY2 else "w")
+        f = path.open("w")
     except (IOError, OSError):
         self.warn("cache could not write path {path}", path=path)
     else:


### PR DESCRIPTION
fails with ImportError and we don't support Python 2

r? @ajvb 