### PR TITLE
Bpitts/aws ec2 ebs piops

### DIFF
--- a/aws/ec2/helpers.py
+++ b/aws/ec2/helpers.py
@@ -292,6 +292,7 @@ def is_ebs_volume_encrypted(ebs):
     """
     return ebs["Encrypted"]
 
+
 def is_ebs_volume_piops(ebs):
     """
     Checks if the EBS volume type is provisioned iops

--- a/aws/ec2/helpers.py
+++ b/aws/ec2/helpers.py
@@ -292,6 +292,29 @@ def is_ebs_volume_encrypted(ebs):
     """
     return ebs["Encrypted"]
 
+def is_ebs_volume_piops(ebs):
+    """
+    Checks if the EBS volume type is provisioned iops
+
+    >>> is_ebs_volume_piops({'VolumeType': 'io1'})
+    True
+    >>> is_ebs_volume_piops({'VolumeType': 'standard'})
+    False
+    >>> is_ebs_volume_piops({})
+    Traceback (most recent call last):
+    ...
+    KeyError: 'VolumeType'
+    >>> is_ebs_volume_piops(0)
+    Traceback (most recent call last):
+    ...
+    TypeError: 'int' object is not subscriptable
+    >>> is_ebs_volume_piops(None)
+    Traceback (most recent call last):
+    ...
+    TypeError: 'NoneType' object is not subscriptable
+    """
+    return ebs["VolumeType"].startswith("io")
+
 
 def is_ebs_snapshot_public(ebs_snapshot):
     """

--- a/aws/ec2/test_ec2_ebs_volume_not_piops.py
+++ b/aws/ec2/test_ec2_ebs_volume_not_piops.py
@@ -1,0 +1,12 @@
+import pytest
+
+from aws.ec2.resources import ec2_ebs_volumes
+from aws.ec2.helpers import is_ebs_volume_piops
+
+
+@pytest.mark.ec2
+@pytest.mark.parametrize(
+    "ec2_ebs_volume", ec2_ebs_volumes(), ids=lambda ebs: ebs["VolumeId"]
+)
+def test_ec2_ebs_volume_encrypted(ec2_ebs_volume):
+    assert not is_ebs_volume_piops(ec2_ebs_volume)

--- a/aws/iam/meta_test_resources.py
+++ b/aws/iam/meta_test_resources.py
@@ -1,4 +1,4 @@
-from dateutil.parser import parse
+from dateutil.parser import isoparse
 
 from aws.iam.resources import iam_users, iam_inline_policies
 
@@ -7,8 +7,8 @@ def test_iam_users():
     assert iam_users() == [
         {
             "Arn": "arn:aws:iam::123456789012:user/hobbes",
-            "CreateDate": parse("1985-11-18T00:01:10+00:00", ignoretz=True),
-            "PasswordLastUsed": parse("2018-01-09T20:43:00+00:00", ignoretz=True),
+            "CreateDate": isoparse("1985-11-18T00:01:10+00:00"),
+            "PasswordLastUsed": isoparse("2018-01-09T20:43:00+00:00"),
             "Path": "/",
             "UserId": "H0BBIHMA0CZ0R0K0MN00C",
             "UserName": "tigerone",
@@ -16,8 +16,8 @@ def test_iam_users():
         },
         {
             "Arn": "arn:aws:iam::123456789012:user/calvin",
-            "CreateDate": parse("1985-11-18T00:01:10+00:00", ignoretz=True),
-            "PasswordLastUsed": parse("2008-01-09T20:43:00+00:00", ignoretz=True),
+            "CreateDate": isoparse("1985-11-18T00:01:10+00:00"),
+            "PasswordLastUsed": isoparse("2008-01-09T20:43:00+00:00"),
             "Path": "/",
             "UserId": "CALCIHMA0CZ0R0K0MN00C",
             "UserName": "spacemanspiff",

--- a/cache.py
+++ b/cache.py
@@ -7,7 +7,7 @@ import functools
 import json
 
 import py
-from dateutil.parser import parse
+from dateutil.parser import isoparse
 
 
 def json_iso_datetimes(obj):
@@ -28,7 +28,7 @@ def json_iso_datetime_string_to_datetime(obj):
             continue
 
         try:
-            obj[k] = parse(v, ignoretz=True)
+            obj[k] = isoparse(v)
         except (OverflowError, ValueError):
             pass
 

--- a/cache.py
+++ b/cache.py
@@ -36,7 +36,7 @@ def json_iso_datetime_string_to_datetime(obj):
 
 
 def datetime_encode_set(self, key, value):
-    """ save value for the given key.
+    """save value for the given key.
 
     :param key: must be a ``/`` separated value. Usually the first
          name is the name of your plugin or your application.
@@ -61,7 +61,7 @@ def datetime_encode_set(self, key, value):
 
 
 def datetime_encode_get(self, key, default):
-    """ return cached value for the given key.  If no value
+    """return cached value for the given key.  If no value
     was yet cached or the value cannot be read, the specified
     default is returned.
 


### PR DESCRIPTION
Cloudops does not want to use any provisioned iops volumes in EC2. This test will let us catch any places where we are.

In addition to the test itself, I've had to change the cache patch to make it more strict when converting strings to datetimes. The volume type `st1` was being incorrectly converted to `datetime.datetime(2020, 9, 1, 0, 0)`.

I'm unsyre if this will negatively affect tests for any other providers.