### PR TITLE
Add test to verify that all EIPs are bound to instances.

### DIFF
--- a/aws/ec2/helpers.py
+++ b/aws/ec2/helpers.py
@@ -269,6 +269,11 @@ def ec2_security_group_test_id(ec2_security_group):
     return "{0[GroupId]} {0[GroupName]}".format(ec2_security_group)
 
 
+def ec2_address_id(ec2_address):
+    """Format an Elastic IP address."""
+    return ec2_address["PublicIp"]
+
+
 def is_ebs_volume_encrypted(ebs):
     """
     Checks the EBS volume 'Encrypted' value.

--- a/aws/ec2/resources.py
+++ b/aws/ec2/resources.py
@@ -102,6 +102,16 @@ def ec2_vpcs():
     )
 
 
+def ec2_addresses():
+    "https://botocore.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_addresses"
+    return (
+        botocore_client.get("ec2", "describe_addresses", [], {})
+        .extract_key("Addresses")
+        .flatten()
+        .values()
+    )
+
+
 def ec2_security_groups_with_in_use_flag():
     """Returns security groups with an additional "InUse" key,
     which is True if it is associated with at least one resource.

--- a/aws/ec2/test_ec2_all_eips_bound.py
+++ b/aws/ec2/test_ec2_all_eips_bound.py
@@ -1,0 +1,11 @@
+import pytest
+
+from aws.ec2.helpers import ec2_address_id
+from aws.ec2.resources import ec2_addresses
+
+
+@pytest.mark.ec2
+@pytest.mark.parametrize("ec2_address", ec2_addresses(), ids=ec2_address_id)
+def test_ec2_all_eips_bound(ec2_address):
+    """Checks whether all EIPs are bound to instances."""
+    assert ec2_address.get("InstanceId"), "No associated instance."


### PR DESCRIPTION
In the cloudops-dev account, this test actually finds more unbound IPs than bound IPs, and there are valid use cases for unbound IPs. This test may still be useful, and it was on our list of desired tests.