### PR TITLE
elb: add test for http desync setting

### DIFF
--- a/aws/elb/resources.py
+++ b/aws/elb/resources.py
@@ -1,7 +1,7 @@
 from conftest import botocore_client
 
 
-def elbs():
+def elbs(with_tags=True):
     """
     http://botocore.readthedocs.io/en/latest/reference/services/elb.html#ElasticLoadBalancing.Client.describe_load_balancers
     """
@@ -11,6 +11,9 @@ def elbs():
         .flatten()
         .values()
     )
+
+    if not with_tags:
+        return elbs
 
     elbs_with_tags = []
     for elb in elbs:
@@ -46,3 +49,25 @@ def elbs_v2():
         .flatten()
         .values()
     )
+
+
+def elb_attributes(elb):
+    """
+    https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/elb.html#ElasticLoadBalancing.Client.describe_load_balancer_attributes
+    """
+    return (
+        botocore_client.get(
+            "elb",
+            "describe_load_balancer_attributes",
+            [],
+            call_kwargs={"LoadBalancerName": elb["LoadBalancerName"]},
+            regions=[elb["__pytest_meta"]["region"]],
+        )
+        .extract_key("LoadBalancerAttributes")
+        .debug()
+        .values()
+    )[0]
+
+
+def elbs_with_attributes():
+    return [(elb, elb_attributes(elb),) for elb in elbs(with_tags=False)]

--- a/aws/elb/test_elb_desync_mode.py
+++ b/aws/elb/test_elb_desync_mode.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from aws.elb.resources import elbs_with_attributes
+
+
+@pytest.mark.elb
+@pytest.mark.parametrize(
+    "elb_with_attrs",
+    elbs_with_attributes(),
+    ids=lambda e: e["LoadBalancerName"] if isinstance(e, dict) else None,
+)
+def test_elb_instance_desync_mode(elb_with_attrs):
+    """
+    Checks ELB HTTP desync mode:
+
+    * is not 'monitor' mode
+
+    >>> test_elb_instance_desync_mode((
+    ...     {"LoadBalancerName": "old-doctest-elb", "CreatedTime": datetime(2020, 9, 1).astimezone(tz=timezone.utc), },
+    ...     {"AdditionalAttributes": [{"Key": "elb.http.desyncmitigationmode", "Value": "monitor"}]},
+    ... ))
+    Traceback (most recent call last):
+        ...
+    AssertionError: ELB old-doctest-elb using desync monitor mode
+    assert 'monitor' != 'monitor'
+    >>> test_elb_instance_desync_mode((
+    ...     {"LoadBalancerName": "new-doctest-elb", "CreatedTime": datetime(2020, 10, 1).astimezone(tz=timezone.utc), },
+    ...     {"AdditionalAttributes": [{"Key": "elb.http.desyncmitigationmode", "Value": "monitor"}]},
+    ... ))
+    Traceback (most recent call last):
+        ...
+    AssertionError: ELB new-doctest-elb using desync monitor mode
+    assert 'monitor' != 'monitor'
+
+    * is 'defensive' or 'strictest' for ELBs created <= 2020-09-01
+
+    >>> test_elb_instance_desync_mode((
+    ...     {"LoadBalancerName": "old-doctest-elb", "CreatedTime": datetime(2020, 9, 1).astimezone(tz=timezone.utc), },
+    ...     {"AdditionalAttributes": [{"Key": "elb.http.desyncmitigationmode", "Value": "strictest"}]},
+    ... ))
+    >>> test_elb_instance_desync_mode((
+    ...     {"LoadBalancerName": "old-doctest-elb", "CreatedTime": datetime(2020, 9, 1).astimezone(tz=timezone.utc), },
+    ...     {"AdditionalAttributes": [{"Key": "elb.http.desyncmitigationmode", "Value": "defensive"}]},
+    ... ))
+
+    * is 'strictest' for ELBs created > 2020-09-01
+
+    >>> test_elb_instance_desync_mode((
+    ...     {"LoadBalancerName": "new-doctest-elb", "CreatedTime": datetime(2020, 10, 1).astimezone(tz=timezone.utc), },
+    ...     {"AdditionalAttributes": [{"Key": "elb.http.desyncmitigationmode", "Value": "strictest"}]},
+    ... ))
+    >>> test_elb_instance_desync_mode((
+    ...     {"LoadBalancerName": "new-doctest-elb", "CreatedTime": datetime(2020, 10, 1).astimezone(tz=timezone.utc), },
+    ...     {"AdditionalAttributes": [{"Key": "elb.http.desyncmitigationmode", "Value": "defensive"}]},
+    ... ))
+    Traceback (most recent call last):
+        ...
+    AssertionError: ELB new-doctest-elb (created 2020-10-01) using desync mode defensive instead of {'strictest'}
+    assert 'defensive' in {'strictest'}
+
+    """
+    elb, attrs = elb_with_attrs
+    elb_name = elb["LoadBalancerName"]
+
+    for attr in attrs["AdditionalAttributes"]:
+        if attr["Key"] == "elb.http.desyncmitigationmode":
+            desync_mode = attr["Value"]
+            break
+
+    created_time = elb["CreatedTime"]
+    assert desync_mode != "monitor", "ELB {} using desync monitor mode".format(elb_name)
+
+    if created_time <= datetime(2020, 9, 1).astimezone(tz=timezone.utc):
+        acceptable_modes = {"defensive", "strictest"}
+    else:
+        acceptable_modes = {"strictest"}
+
+    assert (
+        desync_mode in acceptable_modes
+    ), "ELB {} (created {}) using desync mode {} instead of {}".format(
+        elb_name, created_time.date(), desync_mode, acceptable_modes
+    )

--- a/aws/elb/test_elb_instances_attached.py
+++ b/aws/elb/test_elb_instances_attached.py
@@ -5,7 +5,7 @@ from aws.elb.resources import elbs
 
 @pytest.mark.elb
 @pytest.mark.parametrize(
-    "elb", elbs(), ids=lambda e: e["LoadBalancerName"],
+    "elb", elbs(), ids=lambda e: e["LoadBalancerName"] if isinstance(e, dict) else None,
 )
 def test_elb_instances_attached(elb):
     """


### PR DESCRIPTION
Assuming https://docs.google.com/document/d/1yKLDxZ9S9N456ZPh4qEM0GY2DrMZqsqG69ByCSELjzE/edit is approved this PR adds a test to check whether ELBs are deployed in HTTP Desync strictest mode. I have a doctest for the test itself, but have not functional tested that the resources change fetches the right data. 

We would need to add exemptions for current ELBs, but shouldn't need to for new ELBs.

Alternatively, we could change this to a negative test to make sure we're not running in `monitor` mode anywhere and not add exemptions for existing services.

r? @ajvb 

cc @sciurus @jbuck 