### PR TITLE
Add test for checking specific versions of GKE

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -53,6 +53,11 @@ aws:
 gcp:
   allowed_org_domains:
     - mygsuiteorg.com
+  allowed_gke_versions:
+    - 1.15.12-gke.20
+    - 1.16.13-gke.401
+    - 1.17.9-gke.1504
+    - 1.18.6-gke.3504
 gsuite:
   domain: 'mygsuiteorg.com'
   min_number_of_owners: 2

--- a/custom_config.py
+++ b/custom_config.py
@@ -105,6 +105,7 @@ class AWSConfig(CustomConfigMixin):
 class GCPConfig:
     def __init__(self, config):
         self.allowed_org_domains = config.get("allowed_org_domains", [])
+        self.allowed_gke_versions = config.get("allowed_gke_versions", [])
 
 
 class GSuiteConfig(CustomConfigMixin):

--- a/gcp/compute/test_only_allowed_gke_versions.py
+++ b/gcp/compute/test_only_allowed_gke_versions.py
@@ -1,0 +1,32 @@
+import pytest
+
+from gcp.compute.resources import clusters
+from conftest import gcp_client
+
+
+@pytest.fixture
+def allowed_gke_versions(pytestconfig):
+    return pytestconfig.custom_config.gcp.allowed_gke_versions
+
+
+@pytest.mark.gcp_compute
+@pytest.mark.parametrize(
+    "cluster", clusters(), ids=lambda c: c["name"] if isinstance(c, dict) else None
+)
+def test_only_allowed_gke_versions(cluster, allowed_gke_versions):
+    """
+    Tests if GKE version is within allowed list of GKE versions.
+
+    Useful for checking upgrade status after a vulnerability is released, as in:
+        - https://cloud.google.com/kubernetes-engine/docs/security-bulletins#gcp-2020-012
+    """
+    assert (
+        cluster["currentMasterVersion"] in allowed_gke_versions
+    ), "Current GKE master version ({}) is not in the list of allowed GKE versions.".format(
+        cluster["currentMasterVersion"]
+    )
+    assert (
+        cluster["currentNodeVersion"] in allowed_gke_versions
+    ), "Current GKE node version ({}) is not in the list of allowed GKE versions.".format(
+        cluster["currentNodeVersion"]
+    )


### PR DESCRIPTION
For assistance with new vulns like https://cloud.google.com/kubernetes-engine/docs/security-bulletins#gcp-2020-012
