### PR TITLE
Ensure GKE nodes are on a recent rather than just a valid version

### DIFF
--- a/gcp/compute/test_gke_version_up_to_date.py
+++ b/gcp/compute/test_gke_version_up_to_date.py
@@ -13,9 +13,7 @@ def server_config():
 
 @pytest.mark.gcp_compute
 @pytest.mark.parametrize(
-    "cluster",
-    clusters(),
-    ids=lambda c: get_param_id(c, "name"),
+    "cluster", clusters(), ids=lambda c: get_param_id(c, "name"),
 )
 def test_gke_version_up_to_date(cluster, server_config):
     """

--- a/gcp/compute/test_gke_version_up_to_date.py
+++ b/gcp/compute/test_gke_version_up_to_date.py
@@ -13,7 +13,9 @@ def server_config():
 
 @pytest.mark.gcp_compute
 @pytest.mark.parametrize(
-    "cluster", clusters(), ids=lambda c: get_param_id(c, "name"),
+    "cluster",
+    clusters(),
+    ids=lambda c: get_param_id(c, "name"),
 )
 def test_gke_version_up_to_date(cluster, server_config):
     """
@@ -27,7 +29,7 @@ def test_gke_version_up_to_date(cluster, server_config):
         cluster["currentMasterVersion"]
     )
     assert (
-        cluster["currentNodeVersion"] in server_config["validNodeVersions"]
-    ), "Current GKE node version ({}) is not in the list of valid node versions.".format(
-        cluster["currentNodeVersion"]
+        cluster["currentNodeVersion"] == cluster["currentMasterVersion"]
+    ), "Current GKE node version ({}) is not the same as the master version ({}).".format(
+        cluster["currentNodeVersion"], cluster["currentMasterVersion"]
     )

--- a/gcp/compute/test_gke_version_up_to_date.py
+++ b/gcp/compute/test_gke_version_up_to_date.py
@@ -29,7 +29,7 @@ def test_gke_version_up_to_date(cluster, server_config):
         cluster["currentMasterVersion"]
     )
     assert (
-        cluster["currentNodeVersion"] == cluster["currentMasterVersion"]
-    ), "Current GKE node version ({}) is not the same as the master version ({}).".format(
-        cluster["currentNodeVersion"], cluster["currentMasterVersion"]
+        cluster["currentNodeVersion"] in server_config["validMasterVersions"]
+    ), "Current GKE node version ({}) is not in the list of valid master versions.".format(
+        cluster["currentNodeVersion"]
     )


### PR DESCRIPTION
Before, the test checked if the node version is in validNodeVersions. However, unlike the short validMasterVersions the list in validNodeVersions is very long and goes all the way back to k8s 1.6. Thus, right now this does not actually test that the node version is up-to-date.

I initially thought to just check that the node version matched the master version, but realized this is not a good idea since google doesn't upgrade clusters and nodes in lockstep.

Instead, I've changed the check to verify that the node version is in the list of valid master versions. That should ensure we're on a recent version and still pass in the gap between cluster and node upgrades.

I've been unable to test locally and raised that in svc-auditing.