### PR TITLE
Fix 302 add cli bin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-  - "3.6"
-  - "3.7"
   - "3.8"
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ python:
   - "3.8"
 sudo: required
 
-before_install:
-   - curl -LO https://github.com/BurntSushi/ripgrep/releases/download/0.8.1/ripgrep_0.8.1_amd64.deb
-   - sudo dpkg -i ripgrep_0.8.1_amd64.deb
-
 install:
   - make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install --upgrade --no-cache-dir -r requirements.txt
 
+COPY frost/* frost/
 COPY * ./
+RUN python setup.py install
 
 USER app
-ENTRYPOINT [ ]
+ENTRYPOINT [ "frost" ]

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,6 @@ AWS_PROFILE := default
 
 PYTEST_OPTS := ''
 
-PYTHON_MIN_VERSION := 3.6
-PYTHON_VER_WARNING = $(warning Warning! Frost supports Python $(PYTHON_MIN_VERSION), \
-		      you're running $(shell python -V))
-PYTHON_VER_ERROR = $(error Frost supports Python $(PYTHON_MIN_VERSION), \
-		      you're running $(shell python -V))
-
 all: check_venv
 	frost test
 
@@ -24,8 +18,6 @@ awsci: check_venv
 check_venv:
 ifeq ($(VIRTUAL_ENV),)
 	$(error "Run frost from a virtualenv (try 'make install && source venv/bin/activate')")
-else
-	python -V | grep $(PYTHON_MIN_VERSION) || true ; $(PYTHON_VER_WARNING)
 endif
 
 check_conftest_imports:
@@ -86,7 +78,6 @@ metatest:
 
 venv:
 	python3 -m venv venv
-	./venv/bin/python -V | grep $(PYTHON_MIN_VERSION) || true; $(PYTHON_VER_WARNING)
 
 build-image:
 	docker build -t localhost/frost:latest .

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ all: check_venv
 	frost test
 
 awsci: check_venv
-	frost test --continue-on-collection-errors aws/ \
-		--ignore aws/ec2/test_ec2_security_group_in_use.py \
+	frost test --continue-on-collection-errors -m aws \
+		-k "not test_ec2_security_group_in_use" \
 		--json=results-$(AWS_PROFILE)-$(TODAY).json $(PYTEST_OPTS)
 
 check_venv:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: check_venv
 	frost test
 
 awsci: check_venv
-	frost test --continue-on-collection-errors -m aws \
+	frost test --continue-on-collection-errors -m aws aws/**/*.py \
 		-k "not test_ec2_security_group_in_use" \
 		--json=results-$(AWS_PROFILE)-$(TODAY).json $(PYTEST_OPTS)
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ black: check_venv
 	pre-commit run black --all-files
 
 install: venv
-	( . venv/bin/activate && pip install -U pip && pip install -r requirements.txt  && pre-commit install )
+	( . venv/bin/activate && pip install -U pip && pip install -r requirements.txt && python setup.py develop && pre-commit install )
 
 setup_gsuite: check_venv
 	python -m bin.auth.setup_gsuite

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ PYTHON_VER_ERROR = $(error Frost supports Python $(PYTHON_MIN_VERSION), \
 		      you're running $(shell python -V))
 
 all: check_venv
-	pytest
+	frost test
 
 awsci: check_venv
-	pytest --continue-on-collection-errors aws/ \
+	frost test --continue-on-collection-errors aws/ \
 		--ignore aws/ec2/test_ec2_security_group_in_use.py \
 		--json=results-$(AWS_PROFILE)-$(TODAY).json $(PYTEST_OPTS)
 
@@ -38,7 +38,7 @@ clean: clean-cache clean-python
 
 clean-cache: check_venv
 	@# do as little work as possible to clear the cache, and guarantee success
-	pytest --cache-clear --continue-on-collection-errors \
+	frost test  --cache-clear --continue-on-collection-errors \
 		--collect-only -m "no_such_marker" \
 		--noconftest --tb=no --disable-warnings --quiet \
 	    || true
@@ -51,10 +51,11 @@ doc-build:
 	make -C docs html
 
 doctest: check_venv
-	pytest -vv --doctest-modules --doctest-glob='*.py' -s --offline --debug-calls $(shell find . -type f -name '*.py' | grep -v venv | grep -v .pyenv | grep -v setup.py)
+	frost test -vv --doctest-modules --doctest-glob='*.py' -s --offline --debug-calls $(shell find . -type f -name '*.py' | grep -v venv | grep -v .pyenv | grep -v setup.py)
+	 --doctest-modules -s --offline --debug-calls
 
 coverage: check_venv
-	pytest --cov-config .coveragerc --cov=. \
+	frost test --cov-config .coveragerc --cov=. \
 		--aws-profiles example-account \
 		-o python_files=meta_test*.py \
 		-o cache_dir=./example_cache/ \
@@ -79,7 +80,7 @@ stage-docs: docs
 	git add --all --force docs/_build/html
 
 metatest:
-	pytest --aws-profiles example-account \
+	frost test --aws-profiles example-account \
 		-o python_files=meta_test*.py \
 		-o cache_dir=./example_cache/
 

--- a/README.md
+++ b/README.md
@@ -1,61 +1,135 @@
 # Frost
 
+[![PyPI version](https://badge.fury.io/py/frost.svg)](https://badge.fury.io/py/frost)
+
 ![frost snowman logo](docs/frost-snowman-logo.png?raw=true)
 
-Clients and [pytest](https://docs.pytest.org/en/latest/index.html)
-tests for checking that third party services the @foxsec team uses are
-configured correctly.
-
-We trust third party services to return their status correctly, but
-want to answer questions whether they are configured properly such as:
+HTTP clients and a wrapper around
+[pytest](https://docs.pytest.org/en/latest/index.html) tests to verify
+that third party services are configured correctly. For example:
 
 * Are our AWS DB snapshots publicly accessible?
-* Is there a dangling DNS entry in Route53?
-* Will someone get paged when an alert goes off?
+* Are there dangling DNS entries in Route53?
 
 ## Usage
 
-### Requirements
-
-* [docker](https://docs.docker.com/get-docker/)
-
 ### Installing
 
+1. install [Python 3.8](https://www.python.org/downloads/)
+1. Run `pip install frost`
+
+### Usage
+
 ```console
-docker pull mozilla/frost
+$ frost --help
+Usage: frost [OPTIONS] COMMAND [ARGS]...
+
+  FiRefox Operations Security Testing API clients and tests
+
+Options:
+  --version  Show the version and exit.
+  --help     Show this message and exit.
+
+  Commands:
+    list  Lists available test filenames packaged with frost.
+    test  Run pytest tests passing all trailing args to pytest.
+
+$ frost test --help
+Usage: frost test [OPTIONS] [PYTEST_ARGS]...
+
+  Run pytest tests passing all trailing args to pytest.
+
+  Adds the pytest args:
+
+  -s to disable capturing stdout
+  https://docs.pytest.org/en/latest/capture.html
+
+  and frost specific arg:
+
+  --debug-calls to print AWS API calls
+
+Options:
+  --help  Show this message and exit.
 ```
 
 ### Running
 
-```console
-docker run --rm mozilla/frost pytest -h
-```
-
 To fetch RDS resources from the cache or AWS API and check that
 backups are enabled for DB instances for [the configured aws
 profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html)
-named `default` in the `us-west-2` region run:
+named `default` in the `us-west-2` region
+
+
+1. find the test file path:
 
 ```console
-docker run --rm mozilla/frost pytest aws/rds/test_rds_db_instance_backup_enabled -s --aws-profiles default --debug-calls
+$ frost list | grep rds
+./aws/rds/test_rds_db_instance_backup_enabled.py
+./aws/rds/test_rds_db_snapshot_encrypted.py
+./aws/rds/test_rds_db_instance_is_postgres_with_invalid_certificate.py
+./aws/rds/test_rds_db_instance_encrypted.py
+./aws/rds/test_rds_db_security_group_does_not_grant_public_access.py
+./aws/rds/test_rds_db_instance_not_publicly_accessible_by_vpc_sg.py
+./aws/rds/test_rds_db_instance_minor_version_updates_enabled.py
+./aws/rds/test_rds_db_instance_is_multiaz.py
+./aws/rds/test_rds_db_snapshot_not_publicly_accessible.py
 ```
 
-The options include the pytest option:
+Note: **packaged frost tests are relative to the frost install**
 
-* [`-s`](https://docs.pytest.org/en/latest/capture.html) to disable capturing stdout so we can see the progress fetching AWS resources
+1. run the test:
+
+```console
+frost test aws/rds/test_rds_db_instance_backup_enabled.py --aws-profiles default
+```
 
 Frost adds the options:
 
-* `--debug-calls` for printing (with `-s`) API calls we make
 * `--aws-profiles` for selecting one or more AWS profiles to fetch resources for or the AWS default profile / `AWS_PROFILE` environment variable
 * `--gcp-project-id` for selecting the GCP project to test. **Required for GCP tests**
 * `--offline` a flag to tell HTTP clients to not make requests and return empty params
 * [`--config`](#custom-test-config) path to test custom config file
 
-and produces output like the following showing a DB instance with backups disabled:
+and produces output showing calls to the AWS API and failing for a DB
+instance with backups disabled:
 
 ```console
-# TODO: add example output back
+============================================================ test session starts ============================================================
+platform linux -- Python 3.8.2, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
+rootdir: /home/gguthe/frost
+plugins: json-0.4.0, cov-2.10.0, html-1.20.0, metadata-1.10.0
+collecting ... calling AWSAPICall(profile='default, region='ap-northeast-1', service='rds', method='describe_db_instances', args=[], kwargs={})
+calling AWSAPICall(profile='default, region='ap-northeast-2', service='rds', method='describe_db_instances', args=[], kwargs={})
+calling AWSAPICall(profile='default, region='ap-south-1', service='rds', method='describe_db_instances', args=[], kwargs={})
+calling AWSAPICall(profile='default, region='ap-southeast-1', service='rds', method='describe_db_instances', args=[], kwargs={})
+calling AWSAPICall(profile='default, region='ap-southeast-2', service='rds', method='describe_db_instances', args=[], kwargs={})
+...
+calling AWSAPICall(profile='default, region='us-west-2', service='rds', method='list_tags_for_resource', args=[], kwargs={'ResourceName': 'arn:aws:rds:us-west-2:redacted:db:test-db-ro-dev1'})
+collected 21 items
+
+aws/rds/test_rds_db_instance_backup_enabled.py F....................
+
+================================================================= FAILURES ==================================================================
+____________________________________ test_rds_db_instance_backup_enabled[test-db-ro-dev1] ___________________________________________________
+
+rds_db_instance = {'AllocatedStorage': 250, 'AutoMinorVersionUpgrade': True, 'AvailabilityZone': 'us-east-1a', 'BackupRetentionPeriod': 0, ..
+.}
+
+    @pytest.mark.rds
+    @pytest.mark.parametrize(
+        "rds_db_instance", rds_db_instances_with_tags(), ids=get_db_instance_id,
+    )
+    def test_rds_db_instance_backup_enabled(rds_db_instance):
+>       assert (
+            rds_db_instance["BackupRetentionPeriod"] > 0
+        ), "Backups disabled for {}".format(rds_db_instance["DBInstanceIdentifier"])
+E       AssertionError: Backups disabled for test-db-ro-dev1
+E       assert 0 > 0
+
+aws/rds/test_rds_db_instance_backup_enabled.py:12: AssertionError
+========================================================== short test summary info ==========================================================
+FAILED aws/rds/test_rds_db_instance_backup_enabled.py::test_rds_db_instance_backup_enabled[test-db-ro-dev1] - AssertionError...
+======================================================= 2 failed, 21 passed in 14.32s =======================================================
 ```
 
 #### IAM Policy for frost
@@ -133,6 +207,7 @@ gcloud [--project <project name>] services enable sqladmin.googleapis.com
 #### Setting up GSuite tests
 
 Make sure to have an OAuth2 app created and have the `client_secret.json` file in `~/.credentials` and then run:
+
 ```
 make setup_gsuite
 ```
@@ -315,7 +390,7 @@ And results in a severity and severity marker being included in the
 json metadata:
 
 ```console
-docker run --rm mozilla/frost pytest -s --aws-profiles stage --aws-require-tags Name Type App Stack aws/ec2/test_ec2_instance_has_required_tags.py --config config.yaml.example --json=report.json
+frost test -s --aws-profiles stage --aws-require-tags Name Type App Stack -k test_ec2_instance_has_required_tags --config config.yaml.example --json=report.json
 ...
 ```
 
@@ -572,13 +647,13 @@ Notes:
 * we add markers for the services we're fetching data from
 
 
-1. Running it we see that one of the IPs is an AWS IP:
+1. Running `frost test` with the test file explicitly included we see that one of the IPs is an AWS IP:
 
 ```console
-docker run --rm mozilla/frost pytest httpbin/test_httpbin_ip_in_aws.py
+frost test httpbin/test_httpbin_ip_in_aws.py
 platform darwin -- Python 3.6.2, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
 metadata: {'Python': '3.6.2', 'Platform': 'Darwin-15.6.0-x86_64-i386-64bit', 'Packages': {'pytest': '3.3.2', 'py': '1.5.2', 'pluggy': '0.6.0'}, 'Plugins': {'metadata': '1.5.1', 'json': '0.4.0', 'html': '1.16.1'}}
-rootdir: /Users/gguthe/mozilla/frost, inifile:
+rootdir: /Users/gguthe/frost, inifile:
 plugins: metadata-1.5.1, json-0.4.0, html-1.16.1
 collected 3 items
 

--- a/conftest.py
+++ b/conftest.py
@@ -13,7 +13,6 @@ from heroku.client import HerokuAdminClient
 
 import custom_config
 
-
 collect_ignore_glob = ["*.py"]
 
 botocore_client = None

--- a/frost/__init__.py
+++ b/frost/__init__.py
@@ -1,0 +1,2 @@
+SOURCE_URL = "https://github.com/mozilla/frost"
+VERSION = "0.3.1"

--- a/frost/__init__.py
+++ b/frost/__init__.py
@@ -1,2 +1,2 @@
 SOURCE_URL = "https://github.com/mozilla/frost"
-VERSION = "0.3.1"
+VERSION = "0.4.0"

--- a/frost/cli.py
+++ b/frost/cli.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import glob
 
@@ -59,7 +60,8 @@ def run_pytest(ctx, pytest_args):
 
     --debug-calls to print AWS API calls
     """
-    pytest.main(list(pytest_args))
+    switch_to_frost_parent_directory()
+    pytest.main(["-s", "--debug-calls"] + list(pytest_args))
 
 
 if __name__ == "__main__":

--- a/frost/cli.py
+++ b/frost/cli.py
@@ -1,0 +1,66 @@
+import sys
+import glob
+
+import click
+import pytest
+
+
+FROST_PARENT_DIRECTORY = os.path.dirname(os.path.dirname(__file__))
+
+
+def switch_to_frost_parent_directory():
+    """
+    Changes to the frost CLI parent directory
+
+    This shouldn't be necessary once tests move to frost/
+    """
+    # look up frost/.. to get the repo root dir
+    os.chdir(FROST_PARENT_DIRECTORY)
+
+
+@click.group()
+@click.version_option()
+def cli():
+    """
+    FiRefox Operations Security Testing API clients and tests
+    """
+    pass
+
+
+@cli.command(
+    "list", context_settings=dict(ignore_unknown_options=True,),
+)
+def list_tests():
+    """
+    Lists available test filenames packaged with frost.
+    """
+    switch_to_frost_parent_directory()
+    sys.stdout.writelines(
+        f"{test_file_path}\n"
+        for test_file_path in glob.glob("./**/test*.py", recursive=True)
+        if not ("/venv" in test_file_path or "/build" in test_file_path)
+    )
+
+
+@cli.command(
+    "test", context_settings=dict(ignore_unknown_options=True,),
+)
+@click.argument("pytest_args", nargs=-1, type=click.UNPROCESSED)
+@click.pass_context
+def run_pytest(ctx, pytest_args):
+    """
+    Run pytest tests passing all trailing args to pytest.
+
+    Adds the pytest args:
+
+    -s to disable capturing stdout https://docs.pytest.org/en/latest/capture.html
+
+    and frost specific arg:
+
+    --debug-calls to print AWS API calls
+    """
+    pytest.main(list(pytest_args))
+
+
+if __name__ == "__main__":
+    cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 botocore==1.12.75
+click==7.1.2
 coverage==4.5.3
 google_api_python_client==1.6.1
 pytest-cov==2.10.0

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import setuptools
 
 with open("README.md", "r") as fh:

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python
 
 import setuptools
+from frost import SOURCE_URL, VERSION
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="frost",
-    version="0.3.1",
+    version=VERSION,
     author="Firefox Operations Security Team (foxsec)",
     author_email="foxsec+frost@mozilla.com",
     description="tests for checking that third party services the Firefox Operations Security or foxsec team uses are configured correctly",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/mozilla/frost",
+    url=SOURCE_URL,
     license="MPL2",
     packages=setuptools.find_packages(),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,5 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
     ],
     python_requires=">=3.8",
+    entry_points={"console_scripts": ["frost=frost.cli:cli"],},
 )

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,10 @@ from frost import SOURCE_URL, VERSION
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+install_requires = [
+    line.split("==")[0] for line in open("requirements.txt", "r") if ".git" not in line
+]
+
 setuptools.setup(
     name="frost",
     version=VERSION,
@@ -17,6 +21,7 @@ setuptools.setup(
     url=SOURCE_URL,
     license="MPL2",
     packages=setuptools.find_packages(),
+    install_requires=install_requires,
     classifiers=[
         "Natural Language :: English",
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ setuptools.setup(
         "Natural Language :: English",
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
refs #113 #302

Changes:

* Add a pypi package with CLI bin cmd `frost` ... it doesn't do anything
  * subcommand `frost test` aliased to `pytest -s --debug-calls` run from the frost test root 
  * subcommand `frost list` to print out test file paths (since we default to ignoring all of them)
* Update the readme to use the `frost` command instead of docker (we never published the docker image and would have to mount tests in)
* fix the `awsci` make target to run aws tests

NB: **running tests via `pytest` is unchanged**

Caveats:

* heroku tests are blocked on being able to install the package: https://github.com/hwine/python-herokuadmintools/issues/1
* the test files still live outside the frost package directory

This should:

* provide a single entrypoint independent of pytest for future iteration
* make it easier to split out the fetching and caching functionality as separate subcommands or e.g. `make setup_gsuite` as a distinct subcommand
* provide a way to package and distribute tests without cloning this repo

r? @ajvb