### PR TITLE
Prototype update for SNS tests in #334

### DIFF
--- a/aws/sns/resources.py
+++ b/aws/sns/resources.py
@@ -1,23 +1,23 @@
 from conftest import botocore_client
 
+
 def sns_subscriptions():
     "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#subscription"
-    return(
+    return (
         botocore_client.get("sns", "list_subscriptions", [], {})
         .extract_key("Subscriptions")
         .flatten()
         .values()
     )
 
+
 def sns_subscription_attributes():
     "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#subscription"
-    return [
-        botocore_client.get(
+    for subscription in sns_subscriptions():
+        yield botocore_client.get_details(
+            resource=subscription,
             service_name="sns",
             method_name="get_subscription_attributes",
             call_args=[],
             call_kwargs={"SubscriptionArn": subscription["SubscriptionArn"]},
-        )
-        .extract_key("Attributes")
-        for subscription in sns_subscriptions()
-    ]
+        )["Attributes"]

--- a/aws/sns/test_sns_pending_verified.py
+++ b/aws/sns/test_sns_pending_verified.py
@@ -2,11 +2,12 @@ import pytest
 
 from aws.sns.resources import sns_subscription_attributes
 
+
 @pytest.mark.sns
 @pytest.mark.parametrize(
-    "pending_verification", 
-    sns_subscription_attributes(), 
-    ids=lambda subscription: subscription["PendingVerification"],
+    "subscription_attrs",
+    sns_subscription_attributes(),
+    ids=lambda subscription: subscription["SubscriptionArn"],
 )
-def test_sns_pending_verified(pending_verification):
-    assert pending_verification == "false"
+def test_sns_pending_verified(subscription_attrs):
+    assert subscription_attrs["PendingConfirmation"] == "false"


### PR DESCRIPTION
This prototype encapsulates extracting region and profile in a new method on the `BotocoreClient` to allow the client code to look reasonable. It's not quite what I had in mind, but with the current structure it's the best I could come up with in an hour.

I also factored out the results list into its own class. It was a bit weird that the client stored the results in itself and then modified itself with `extract_key()` and `flatten()`. I simply moved that to a separate class, so subsequent calls to the client don't overwrite the previous results.

The test is now working and passing, but it's terribly slow. I tried it for the dev account, and it makes some 3,000 API calls, so you get rate limited and the client waits and retries. When I limit it to 300 subscriptions, it returns quite quickly, but running it for all subscriptions takes ages.

If the general approach seems reasonable, at least as an incremental improvement over the current situation, I can factor out the changes in the client in a separate PR and clean them up a bit.

Related: #334