### PR TITLE
add --aws-regions cli arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ frost test aws/rds/test_rds_db_instance_backup_enabled.py --aws-profiles default
 Frost adds the options:
 
 * `--aws-profiles` for selecting one or more AWS profiles to fetch resources for or the AWS default profile / `AWS_PROFILE` environment variable
+* `--aws-regions` for selecting one or more AWS regions to test as a CSV e.g. `us-east-1,us-west-2`. **defaults to all regions**
 * `--gcp-project-id` for selecting the GCP project to test. **Required for GCP tests**
 * `--offline` a flag to tell HTTP clients to not make requests and return empty params
 * [`--config`](#custom-test-config) path to test custom config file

--- a/aws/client.py
+++ b/aws/client.py
@@ -163,7 +163,7 @@ def get_aws_resource(
 
 
 class BotocoreClient:
-    def __init__(self, profiles, cache, debug_calls, debug_cache, offline):
+    def __init__(self, profiles, regions, cache, debug_calls, debug_cache, offline):
         self.profiles = profiles or [None]
         self.cache = cache
 
@@ -173,6 +173,8 @@ class BotocoreClient:
 
         if offline:
             self.regions = ["us-east-1"]
+        elif regions:
+            self.regions = regions
         else:
             self.regions = get_available_regions()
 

--- a/conftest.py
+++ b/conftest.py
@@ -30,6 +30,12 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
+        "--aws-regions",
+        type=str,
+        help="Set AWS regions to use as a comma separate list. Defaults to all available AWS regions",
+    )
+
+    parser.addoption(
         "--gcp-project-id",
         type=str,
         help="Set GCP project to test. Required for GCP tests.",
@@ -80,11 +86,18 @@ def pytest_configure(config):
         patch_cache_set(config)
 
     profiles = config.getoption("--aws-profiles")
+    aws_regions = (
+        config.getoption("--aws-regions").split(",")
+        if config.getoption("--aws-regions")
+        else []
+    )
+
     project_id = config.getoption("--gcp-project-id")
     organization = config.getoption("--organization")
 
     botocore_client = BotocoreClient(
         profiles=profiles,
+        regions=aws_regions,
         cache=cache,
         debug_calls=config.getoption("--debug-calls"),
         debug_cache=config.getoption("--debug-cache"),


### PR DESCRIPTION
fixes: #348

functional tests:

- [x] one region
- [x] two region
- [x] no arg defaults to all regions

```console
$ pytest --debug-cache --debug-calls -p 'no:cacheprovider' -s --aws-regions=us-east-1 --aws-profiles='default' aws/ec2/test_ec2_instance_has_required_tags.py
collecting ... calling AWSAPICall(profile='default', region='us-east-1', service='ec2', method='describe_instances', args=[], kwargs={'Filters': [{'Name': 'instance-state-name', 'Values': ['pending', 'running']}]})
...
$ pytest --debug-cache --debug-calls -p 'no:cacheprovider' -s --aws-regions=us-east-1,us-west-2 ...
...
collecting ... calling AWSAPICall(profile='default', region='us-east-1', service='ec2', method='describe_instances', args=[], kwargs={'Filters': [{'Name': 'instance-state-name', 'Values': ['pending', 'running']}]})
calling AWSAPICall(profile='default', region='us-west-2', service='ec2', method='describe_instances', args=[], kwargs={'Filters': [{'Name': 'instance-state-name', 'Values': ['pending', 'running']}]})
collected 123 items                                                                                                                                                     
...
$ » pytest --debug-cache --debug-calls -p 'no:cacheprovider' -s --aws-profiles='default' aws/ec2/test_ec2_instan
ce_has_required_tags.py                                              
========================================================================== test session starts ==========================================================================
platform linux -- Python 3.8.2, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/gguthe/frost                                                                    
plugins: json-0.4.0, cov-2.10.0, html-1.20.0, metadata-1.10.0
collecting ... calling AWSAPICall(profile='default', region='ap-northeast-1', service='ec2', method='describe_instances', args=[], kwargs={'Filters': [{'Na
me': 'instance-state-name', 'Values': ['pending', 'running']}]})
calling AWSAPICall(profile='default', region='ap-northeast-2', service='ec2', method='describe_instances', args=[], kwargs={'Filters': [{'Name': 'instance-
state-name', 'Values': ['pending', 'running']}]})
calling AWSAPICall(profile='default', region='ap-south-1', service='ec2', method='describe_instances', args=[], kwargs={'Filters': [{'Name': 'instance-stat
e-name', 'Values': ['pending', 'running']}]})
...
```