### PR TITLE
Rework GCP code to support folder id arg

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,4 @@
 import argparse
-from sys import exit
 import datetime
 
 import pytest
@@ -101,9 +100,9 @@ def pytest_configure(config):
     project_id = config.getoption("--gcp-project-id")
     folder_id = config.getoption("--gcp-folder-id")
     if project_id is not None and folder_id is not None:
-        # TODO: Probably a better way to cleanly exit than `exit(1)`?
-        print("--gcp-project-id and --gcp-folder-id are mutually exclusive arguments")
-        exit(1)
+        raise Exception(
+            "--gcp-project-id and --gcp-folder-id are mutually exclusive arguments"
+        )
 
     organization = config.getoption("--organization")
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import argparse
+from sys import exit
 import datetime
 
 import pytest
@@ -23,51 +24,56 @@ custom_config_global = None
 
 
 def pytest_addoption(parser):
-    parser.addoption(
+    frost_parser = parser.getgroup("Frost", "Frost's custom arguments")
+    frost_parser.addoption(
         "--aws-profiles",
         nargs="*",
         help="Set default AWS profiles to use. Defaults to the current AWS profile i.e. [None].",
     )
 
-    parser.addoption(
+    frost_parser.addoption(
         "--aws-regions",
         type=str,
         help="Set AWS regions to use as a comma separate list. Defaults to all available AWS regions",
     )
 
-    parser.addoption(
-        "--gcp-project-id",
+    frost_parser.addoption(
+        "--gcp-project-id", type=str, help="Set GCP project to test.",
+    )
+
+    frost_parser.addoption(
+        "--gcp-folder-id",
         type=str,
-        help="Set GCP project to test. Required for GCP tests.",
+        help="Set GCP folder to test. Will test all projects under this folder.",
     )
 
     # While only used for Heroku at the moment, GitHub tests are soon to be
     # added, which will also need an "organization" option. Current plan is to
     # reuse this one.
-    parser.addoption(
+    frost_parser.addoption(
         "--organization",
         type=str,
         help="Set organization to test. Used for Heroku tests.",
     )
 
-    parser.addoption(
+    frost_parser.addoption(
         "--debug-calls", action="store_true", help="Log API calls. Requires -s"
     )
 
-    parser.addoption(
+    frost_parser.addoption(
         "--debug-cache",
         action="store_true",
         help="Log whether API calls hit the cache. Requires -s",
     )
 
-    parser.addoption(
+    frost_parser.addoption(
         "--offline",
         action="store_true",
         default=False,
         help="Instruct service clients to return empty lists and not make HTTP requests.",
     )
 
-    parser.addoption(
+    frost_parser.addoption(
         "--config", type=argparse.FileType("r"), help="Path to the config file."
     )
 
@@ -93,6 +99,12 @@ def pytest_configure(config):
     )
 
     project_id = config.getoption("--gcp-project-id")
+    folder_id = config.getoption("--gcp-folder-id")
+    if project_id is not None and folder_id is not None:
+        # TODO: Probably a better way to cleanly exit than `exit(1)`?
+        print("--gcp-project-id and --gcp-folder-id are mutually exclusive arguments")
+        exit(1)
+
     organization = config.getoption("--organization")
 
     botocore_client = BotocoreClient(
@@ -106,9 +118,8 @@ def pytest_configure(config):
 
     gcp_client = GCPClient(
         project_id=project_id,
-        cache=cache,
+        folder_id=folder_id,
         debug_calls=config.getoption("--debug-calls"),
-        debug_cache=config.getoption("--debug-cache"),
         offline=config.getoption("--offline"),
     )
 
@@ -173,13 +184,15 @@ METADATA_KEYS = [
     "VolumeId",
     "VpcId",
     "__pytest_meta",
-    "name",
     "displayName",
-    "projectId",
-    "uniqueId",
     "id",
+    "kind",
     "members",
+    "name",
+    "project",
+    "projectId",
     "role",
+    "uniqueId",
 ]
 
 
@@ -221,13 +234,6 @@ def get_metadata_from_funcargs(funcargs):
     for k in funcargs:
         if isinstance(funcargs[k], dict):
             metadata = {**metadata, **extract_metadata(funcargs[k])}
-    return metadata
-
-
-def get_metadata(function_args):
-    metadata = get_metadata_from_funcargs(function_args)
-    if gcp_client.get_project_id() != "":
-        metadata["gcp_project_id"] = gcp_client.get_project_id()
     return metadata
 
 
@@ -279,7 +285,7 @@ def pytest_runtest_makereport(item, call):
 
     # only add this during call instead of during any stage
     if report.when == "call" and not isinstance(item, DoctestItem):
-        metadata = get_metadata(item.funcargs)
+        metadata = get_metadata_from_funcargs(item.funcargs)
         markers = {n.name: serialize_marker(n) for n in get_node_markers(item)}
         severity = markers.get("severity", None) and markers.get("severity")["args"][0]
         regression = (

--- a/gcp/bigquery/resources.py
+++ b/gcp/bigquery/resources.py
@@ -2,15 +2,23 @@ from conftest import gcp_client
 
 
 def datasets():
-    datasets = gcp_client.list(
-        "bigquery",
-        "datasets",
-        version="v2",
-        results_key="datasets",
-        call_kwargs={"projectId": gcp_client.get_project_id()},
+    results = []
+    for project_id in gcp_client.project_list:
+        datasets = gcp_client.list(
+            "bigquery",
+            "datasets",
+            version="v2",
+            results_key="datasets",
+            call_kwargs={"projectId": project_id},
+        )
+        results += [
+            get_dataset(d["datasetReference"]["datasetId"], project_id)
+            for d in datasets
+        ]
+    return sum(results, [])
+
+
+def get_dataset(dataset_id, project_id):
+    return gcp_client.get(
+        project_id, "bigquery", "datasets", "datasetId", dataset_id, version="v2"
     )
-    return [get_dataset(d["datasetReference"]["datasetId"]) for d in datasets]
-
-
-def get_dataset(dataset_id):
-    return gcp_client.get("bigquery", "datasets", "datasetId", dataset_id, version="v2")

--- a/gcp/compute/resources.py
+++ b/gcp/compute/resources.py
@@ -27,7 +27,7 @@ def clusters():
 
 def networks_with_instances():
     allInstances = instances()
-    inUseNetworks = []
+    in_use_networks = []
     for network in networks():
         network["instances"] = []
         for instance in allInstances:
@@ -36,21 +36,21 @@ def networks_with_instances():
             ]:
                 network["instances"].append(instance)
         if len(network["instances"]):
-            inUseNetworks.append(network)
+            in_use_networks.append(network)
 
-    return inUseNetworks
+    return in_use_networks
 
 
 def in_use_firewalls():
-    allNetworks = networks_with_instances()
-    inUseFirewalls = []
+    all_networks = networks_with_instances()
+    results = []
     for firewall in firewalls():
         if firewall["disabled"] == True:
             continue
-        for network in allNetworks:
+        for network in all_networks:
             if (
                 network["selfLink"] == firewall["network"]
                 and len(network["instances"]) > 0
             ):
-                inUseFirewalls.append(firewall)
-    return inUseFirewalls
+                results.append(firewall)
+    return results

--- a/gcp/compute/test_gke_version_up_to_date.py
+++ b/gcp/compute/test_gke_version_up_to_date.py
@@ -18,7 +18,7 @@ def server_config():
 def test_gke_version_up_to_date(cluster, server_config):
     """
     Tests if GKE version is up to date by comparing the
-    list of valid master and node versions to what is
+    list of valid master versions to what is
     currently running on the cluster.
     """
     assert (

--- a/gcp/iam/resources.py
+++ b/gcp/iam/resources.py
@@ -2,12 +2,15 @@ from conftest import gcp_client
 
 
 def service_accounts():
-    return gcp_client.list(
-        "iam",
-        "projects.serviceAccounts",
-        results_key="accounts",
-        call_kwargs={"name": "projects/" + gcp_client.get_project_id()},
-    )
+    results = []
+    for project_id in gcp_client.project_list:
+        results += gcp_client.list(
+            "iam",
+            "projects.serviceAccounts",
+            results_key="accounts",
+            call_kwargs={"name": "projects/" + project_id},
+        )
+    return results
 
 
 def service_account_keys(service_account):
@@ -20,12 +23,17 @@ def service_account_keys(service_account):
 
 
 def all_service_account_keys():
+    keys = []
     for sa in service_accounts():
         for key in service_account_keys(sa):
-            yield key
+            keys.append(key)
+    return key
 
 
 def project_iam_bindings():
-    policy = gcp_client.get_project_iam_policy()
-    for binding in policy.get("bindings", []):
-        yield binding
+    bindings = []
+    policies = gcp_client.get_project_iam_policy()
+    for policy in policies:
+        for binding in policy.get("bindings", []):
+            bindings.append(binding)
+    return bindings


### PR DESCRIPTION
Reworks the GCP client, resources, and test code to add support for
passing in a Folder ID and running tests against all of the projects
within that folder.

Alongside that, this includes some stability fixes to the client code,
creates a new "frost" named cli arg group, and removes caching from the
GCP client.

Fixes #339 and #329 