### PR TITLE
ci: enable deploying tags to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,10 @@ install:
 
 script:
   - make black check_conftest_imports doctest coverage
+
+deploy:
+  provider: pypi
+  on:
+    tags: true
+  distributions: sdist bdist_wheel
+  edge: true # opt in to dpl v2 https://docs.travis-ci.com/user/deployment-v2/providers/pypi/


### PR DESCRIPTION
fixes: #344 

Add API token and username available on the master brach with permission to upload new frost packages to pypi as source and bdist wheels for tagged builds.

API token has name "frost-gh-travis-ci" unique ID c3a99f6b-abbc-4315-807a-276a7f103769 and belongs to https://pypi.org/user/mozfoxsec/

I don't have a way to functional test this before landing the change.

r? @ajvb @hwine 