### PR TITLE
Support for allowed ports for GCP firewall tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,24 @@ aws:
   required_amis:
     - ami-00000000000000000
     - ami-55555555555555555
-  whitelisted_ports_global:
+  allowed_ports_global:
     - 25
-  whitelisted_ports:
+  allowed_ports:
+    - test_param_id: '*bastion'
+      ports:
+        - 22
+        - 2222
+gcp:
+  allowed_org_domains:
+    - mygsuiteorg.com
+  allowed_gke_versions:
+    - 1.15.12-gke.20
+    - 1.16.13-gke.401
+    - 1.17.9-gke.1504
+    - 1.18.6-gke.3504
+  allowed_ports_global:
+    - 25
+  allowed_ports:
     - test_param_id: '*bastion'
       ports:
         - 22
@@ -455,12 +470,12 @@ aws:
     - Env
   # Whitelsited ports for the test_ec2_security_group_opens_specific_ports_to_all
   # test for all instances
-  whitelisted_ports_global:
+  allowed_ports_global:
     - 25
   # Whitelsited ports for the test_ec2_security_group_opens_specific_ports_to_all
   # test for specific instances. In this example, we are whitelisting ports 22
   # and 2222 for all security groups that include the word 'bastion' in them.
-  whitelisted_ports:
+  allowed_ports:
     - test_param_id: '*bastion'
       ports:
         - 22

--- a/README.md
+++ b/README.md
@@ -281,8 +281,13 @@ aws:
   required_amis:
     - ami-00000000000000000
     - ami-55555555555555555
+  # Allowed ports for the test_ec2_security_group_opens_specific_ports_to_all
+  # test for all instances
   allowed_ports_global:
     - 25
+  # Allowed ports for the test_ec2_security_group_opens_specific_ports_to_all
+  # test for specific instances. In this example, we are allowing ports 22
+  # and 2222 for all security groups that include the word 'bastion' in them.
   allowed_ports:
     - test_param_id: '*bastion'
       ports:
@@ -296,8 +301,13 @@ gcp:
     - 1.16.13-gke.401
     - 1.17.9-gke.1504
     - 1.18.6-gke.3504
+  # Allowed ports for the test_firewall_opens_any_ports_to_all
+  # test for all firewalls
   allowed_ports_global:
     - 25
+  # Allowed ports for the test_firewall_opens_any_ports_to_all
+  # test for specific firewalls. In this example, we are allowing ports 22
+  # and 2222 for all firewalls that include the word 'bastion' in them.
   allowed_ports:
     - test_param_id: '*bastion'
       ports:
@@ -468,12 +478,12 @@ aws:
     - Type
     - App
     - Env
-  # Whitelsited ports for the test_ec2_security_group_opens_specific_ports_to_all
+  # Allowed ports for the test_ec2_security_group_opens_specific_ports_to_all
   # test for all instances
   allowed_ports_global:
     - 25
-  # Whitelsited ports for the test_ec2_security_group_opens_specific_ports_to_all
-  # test for specific instances. In this example, we are whitelisting ports 22
+  # Allowed ports for the test_ec2_security_group_opens_specific_ports_to_all
+  # test for specific instances. In this example, we are allowing ports 22
   # and 2222 for all security groups that include the word 'bastion' in them.
   allowed_ports:
     - test_param_id: '*bastion'

--- a/aws/ec2/helpers.py
+++ b/aws/ec2/helpers.py
@@ -210,7 +210,7 @@ def ec2_security_group_opens_all_ports_to_all(ec2_security_group):
 
 
 def ec2_security_group_opens_specific_ports_to_all(
-    ec2_security_group, whitelisted_ports=None
+    ec2_security_group, allowed_ports=None
 ):
     """
     Returns True if an ec2 security group includes a permission
@@ -237,8 +237,8 @@ def ec2_security_group_opens_specific_ports_to_all(
     >>> ec2_security_group_opens_specific_ports_to_all([])
     False
     """
-    if whitelisted_ports is None:
-        whitelisted_ports = []
+    if allowed_ports is None:
+        allowed_ports = []
 
     if "IpPermissions" not in ec2_security_group:
         return False
@@ -255,7 +255,7 @@ def ec2_security_group_opens_specific_ports_to_all(
             if from_port == to_port and from_port in [80, 443]:
                 continue
 
-            if from_port == to_port and from_port in whitelisted_ports:
+            if from_port == to_port and from_port in allowed_ports:
                 continue
 
             return True

--- a/aws/ec2/test_ec2_security_group_opens_specific_ports_to_all.py
+++ b/aws/ec2/test_ec2_security_group_opens_specific_ports_to_all.py
@@ -18,11 +18,11 @@ def test_ec2_security_group_opens_specific_ports_to_all(ec2_security_group, aws_
     inbound access on specific ports. Excluded ports are 80 and 443.
     """
     if ec2_security_group["InUse"]:
-        whitelisted_ports = aws_config.get_whitelisted_ports(
+        allowed_ports = aws_config.get_allowed_ports(
             ec2_security_group_test_id(ec2_security_group)
         )
         assert not ec2_security_group_opens_specific_ports_to_all(
-            ec2_security_group, whitelisted_ports
+            ec2_security_group, allowed_ports
         )
     else:
         pytest.skip("Security group not in use")

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -36,8 +36,13 @@ aws:
     - Type
     - App
     - Env
+  # Allowed ports for the test_ec2_security_group_opens_specific_ports_to_all
+  # test for all instances
   allowed_ports_global:
     - 25
+  # Allowed ports for the test_ec2_security_group_opens_specific_ports_to_all
+  # test for specific instances. In this example, we are allowing ports 22
+  # and 2222 for all security groups that include the word 'bastion' in them.
   allowed_ports:
     - test_param_id: '*bastion'
       ports:
@@ -54,8 +59,13 @@ gcp:
     - 1.16.13-gke.401
     - 1.17.9-gke.1504
     - 1.18.6-gke.3504
+  # Allowed ports for the test_firewall_opens_any_ports_to_all
+  # test for all firewalls
   allowed_ports_global:
     - 25
+  # Allowed ports for the test_firewall_opens_any_ports_to_all
+  # test for specific firewalls. In this example, we are allowing ports 22
+  # and 2222 for all firewalls that include the word 'bastion' in them.
   allowed_ports:
     - test_param_id: '*bastion'
       ports:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -36,9 +36,9 @@ aws:
     - Type
     - App
     - Env
-  whitelisted_ports_global:
+  allowed_ports_global:
     - 25
-  whitelisted_ports:
+  allowed_ports:
     - test_param_id: '*bastion'
       ports:
         - 22
@@ -54,6 +54,13 @@ gcp:
     - 1.16.13-gke.401
     - 1.17.9-gke.1504
     - 1.18.6-gke.3504
+  allowed_ports_global:
+    - 25
+  allowed_ports:
+    - test_param_id: '*bastion'
+      ports:
+        - 22
+        - 2222
 gsuite:
   domain: 'mygsuiteorg.com'
   min_number_of_owners: 2

--- a/conftest.py
+++ b/conftest.py
@@ -147,6 +147,11 @@ def aws_config(pytestconfig):
     return pytestconfig.custom_config.aws
 
 
+@pytest.fixture
+def gcp_config(pytestconfig):
+    return pytestconfig.custom_config.gcp
+
+
 def pytest_runtest_setup(item):
     """"""
     if not isinstance(item, DoctestItem):

--- a/gcp/compute/helpers.py
+++ b/gcp/compute/helpers.py
@@ -62,7 +62,7 @@ def does_firewall_open_all_ports_to_all(firewall):
     return False
 
 
-def does_firewall_open_any_ports_to_all(firewall):
+def does_firewall_open_any_ports_to_all(firewall, allowed_ports=None):
     """
     Returns True if firewall has a rule to open any ports (except 80/443) to all. Excludes ICMP.
 
@@ -85,6 +85,9 @@ def does_firewall_open_any_ports_to_all(firewall):
     >>> does_firewall_open_any_ports_to_all({'sourceRanges': ['0.0.0.0/0'], 'allowed': [{'ports': ['22', '80', '443']}]})
     True
     """
+    if allowed_ports is None:
+        allowed_ports = []
+
     if does_firewall_open_all_ports_to_all(firewall):
         return True
 
@@ -98,7 +101,15 @@ def does_firewall_open_any_ports_to_all(firewall):
         if rule.get("IPProtocol", "") == "icmp":
             continue
         for port_rule in rule.get("ports"):
-            if port_rule not in ["80", "443"]:
+            try:
+                port_rule = int(port_rule)
+            except ValueError:
+                return True
+
+            if port_rule in allowed_ports:
+                continue
+
+            if port_rule not in [80, 443]:
                 return True
 
     return False

--- a/gcp/compute/test_firewall_opens_any_ports_to_all.py
+++ b/gcp/compute/test_firewall_opens_any_ports_to_all.py
@@ -6,11 +6,12 @@ from gcp.compute.resources import in_use_firewalls
 
 @pytest.mark.gcp_compute
 @pytest.mark.parametrize("firewall", in_use_firewalls(), ids=firewall_id)
-def test_firewall_opens_any_ports_to_all(firewall):
+def test_firewall_opens_any_ports_to_all(firewall, gcp_config):
     """
     This test confirms that no ports are open to 0.0.0.0/0 (except
     80 and 443 on any VPC.
 
     CIS 3.6, 3.7
     """
-    assert not does_firewall_open_any_ports_to_all(firewall)
+    allowed_ports = gcp_config.get_allowed_ports(firewall_id(firewall))
+    assert not does_firewall_open_any_ports_to_all(firewall, allowed_ports)


### PR DESCRIPTION
Adds support for allowed ports in GCP firewall tests

As well, switch from the term "whitelisted" to "allowed".

Note: Will require a change to all of the configs in our automation code.