### PR TITLE
Small fixes for GCP and service report generator

### DIFF
--- a/gcp/client.py
+++ b/gcp/client.py
@@ -86,7 +86,7 @@ class GCPClient:
                     .getIamPolicy(resource=project_id, body={})
                     .execute()
                 )
-                policies += resp
+                policies.append(resp)
             except HttpError as e:
                 if "has not been used in project" in e._get_reason():
                     continue

--- a/gcp/iam/resources.py
+++ b/gcp/iam/resources.py
@@ -32,7 +32,7 @@ def all_service_account_keys():
 
 def project_iam_bindings():
     bindings = []
-    policies = gcp_client.get_project_iam_policy()
+    policies = gcp_client.get_project_iam_policies()
     for policy in policies:
         for binding in policy.get("bindings", []):
             bindings.append(binding)

--- a/gcp/iam/test_only_allowed_org_accounts.py
+++ b/gcp/iam/test_only_allowed_org_accounts.py
@@ -29,7 +29,9 @@ def test_only_allowed_org_accounts(iam_binding, allowed_org_domains):
 
     if iam_binding["role"] not in EXCLUDED_ROLES:
         for member in iam_binding["members"]:
-            if not member.startswith("serviceAccount"):
+            if not member.startswith("serviceAccount") and not member.startswith(
+                "deleted:serviceAccount"
+            ):
                 assert (
                     member.split("@")[-1] in allowed_org_domains
                 ), "{} was found and is not in the allowed_org_domains".format(member)

--- a/service_report_generator.py
+++ b/service_report_generator.py
@@ -55,7 +55,7 @@ from collections import defaultdict
 STATUSES_TO_LIST = ["fail", "warn", "err"]
 
 service_json_template = {
-    "name": "pytest",
+    "name": "frost",
     "tool_url": "https://github.com/mozilla/frost",
     "version": 1,
     "created_at": "",


### PR DESCRIPTION
* Fix typo in `gcp.iam.resources.project_iam_bindings()`
* Add `deleted` variant to the service account filter for `test_only_allowed_org_accounts`
* s/pytest/frost/ in service report generator