### PR TITLE
Fix Frost exit codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,4 @@ deploy:
     keep_history: true
     local_dir: docs/_build/html/
     on:
-      ### DO NOT MERGE ###
-      branch: hwine/doc-new-service
+      branch: master

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ doc-preview: check_venv
 	sphinx-autobuild $(AUTOBUILD_OPTS) "docs/" "docs/_build/html/" $(SPHINXOPTS) $(O)
 
 doctest: check_venv
-	frost test -vv --doctest-modules --doctest-glob='*.py' -s --offline --debug-calls $(shell find . -type f -name '*.py' | grep -v venv | grep -v .pyenv | grep -v setup.py)
-	 --doctest-modules -s --offline --debug-calls
+	frost test -vv --doctest-modules --doctest-glob='*.py' -s --offline --debug-calls $(shell find . -type f -name '*.py' | grep -v venv | grep -v .pyenv | grep -v setup.py) \
+		--doctest-modules -s --offline --debug-calls
 
 coverage: check_venv
 	frost test --cov-config .coveragerc --cov=. \

--- a/aws/client.py
+++ b/aws/client.py
@@ -228,7 +228,7 @@ class BotocoreClient:
     def values(self):
         """Returns the wrapped value
 
-        >>> c = BotocoreClient([None], None, None, None, offline=True)
+        >>> c = BotocoreClient([None], None, None, None, None, offline=True)
         >>> c.results = []
         >>> c.values()
         []
@@ -240,14 +240,14 @@ class BotocoreClient:
         From an iterable of dicts returns the value with the given
         keys discarding other values:
 
-        >>> c = BotocoreClient([None], None, None, None, offline=True)
+        >>> c = BotocoreClient([None], None, None, None, None, offline=True)
         >>> c.results = [{'id': 1}, {'id': 2}]
         >>> c.extract_key('id').results
         [1, 2]
 
         When the key does not exist it returns the second arg which defaults to None:
 
-        >>> c = BotocoreClient([None], None, None, None, offline=True)
+        >>> c = BotocoreClient([None], None, None, None, None, offline=True)
         >>> c.results = [{'id': 1}, {}]
         >>> c.extract_key('id').results
         [1, None]
@@ -255,7 +255,7 @@ class BotocoreClient:
 
         Propagates the '__pytest_meta' key to dicts and lists of dicts:
 
-        >>> c = BotocoreClient([None], None, None, None, offline=True)
+        >>> c = BotocoreClient([None], None, None, None, None, offline=True)
         >>> c.results = [{'Attrs': {'Name': 'Test'}, '__pytest_meta': {'meta': 'dict'}}]
         >>> c.extract_key('Attrs').results
         [{'Name': 'Test', '__pytest_meta': {'meta': 'dict'}}]
@@ -272,7 +272,7 @@ class BotocoreClient:
 
         Errors when the outer dict is missing a meta key:
 
-        >>> c = BotocoreClient([None], None, None, None, offline=True)
+        >>> c = BotocoreClient([None], None, None, None, None, offline=True)
         >>> c.results = [{'Attrs': {'Name': 'Test'}}]
         >>> c.extract_key('Attrs')
         Traceback (most recent call last):
@@ -304,7 +304,7 @@ class BotocoreClient:
         """
         Flattens one level of a nested list:
 
-        >>> c = BotocoreClient([None], None, None, None, offline=True)
+        >>> c = BotocoreClient([None], None, None, None, None, offline=True)
         >>> c.results = [['A', 1], ['B']]
         >>> c.flatten().values()
         ['A', 1, 'B']

--- a/frost/cli.py
+++ b/frost/cli.py
@@ -62,7 +62,9 @@ def run_pytest(ctx, pytest_args):
     --ignore-glob='*.py' to require explicit test specification
     """
     switch_to_frost_parent_directory()
-    pytest.main(["-s", "--debug-calls", "--ignore-glob='*.py'"] + list(pytest_args))
+    sys.exit(
+        pytest.main(["-s", "--debug-calls", "--ignore-glob='*.py'"] + list(pytest_args))
+    )
 
 
 if __name__ == "__main__":

--- a/gcp/iam/resources.py
+++ b/gcp/iam/resources.py
@@ -27,7 +27,7 @@ def all_service_account_keys():
     for sa in service_accounts():
         for key in service_account_keys(sa):
             keys.append(key)
-    return key
+    return keys
 
 
 def project_iam_bindings():


### PR DESCRIPTION
and some little additional fixes

CI has been broken for doctests since the switch to using `frost test`