### PR TITLE
bump version to 0.4.2

### DIFF
--- a/frost/__init__.py
+++ b/frost/__init__.py
@@ -1,2 +1,2 @@
 SOURCE_URL = "https://github.com/mozilla/frost"
-VERSION = "0.4.0"
+VERSION = "0.4.2"


### PR DESCRIPTION
This is `0.4.1` with version bumped to `.2`   since .1 was already tagged.