### PR TITLE
Make sure all test id's are reproducible

### DIFF
--- a/aws/iam/helpers.py
+++ b/aws/iam/helpers.py
@@ -152,7 +152,10 @@ def get_iam_user_name(login):
     return get_param_id(login, "UserName")
 
 
-def get_iam_user_name_only(user):
-    if isinstance(user, dict) and "UserName" in user:
-        return get_iam_user_name(user)
+def get_iam_resource_id(resource):
+    if isinstance(resource, dict) and "UserName" in resource:
+        return get_iam_user_name(resource)
+    if isinstance(resource, list):
+        if len(resource) == 0:
+            return "empty"
     return None

--- a/aws/iam/resources.py
+++ b/aws/iam/resources.py
@@ -132,18 +132,18 @@ def iam_admin_login_profiles():
 
 
 def iam_admin_mfa_devices():
-    "botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_mfa_devices"
+    "https://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_mfa_devices"
     return iam_mfa_devices(iam_admin_users())
 
 
 def iam_user_login_profiles():
     "http://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.get_login_profile"
-    return iam_login_profiles([user for user in iam_users()])
+    return iam_login_profiles(iam_users())
 
 
 def iam_user_mfa_devices():
-    "botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_mfa_devices"
-    return iam_mfa_devices([user for user in iam_users()])
+    "https://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_mfa_devices"
+    return iam_mfa_devices(iam_users())
 
 
 def iam_login_profiles(users):
@@ -163,7 +163,7 @@ def iam_login_profiles(users):
 
 
 def iam_mfa_devices(users):
-    "botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_mfa_devices"
+    "https://botocore.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.list_mfa_devices"
     return [
         botocore_client.get(
             "iam", "list_mfa_devices", [], {"UserName": user["UserName"]}

--- a/aws/iam/test_iam_admin_user_without_mfa.py
+++ b/aws/iam/test_iam_admin_user_without_mfa.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aws.iam.helpers import get_iam_user_name_only
+from aws.iam.helpers import get_iam_resource_id
 from aws.iam.resources import iam_admin_login_profiles, iam_admin_mfa_devices
 
 
@@ -8,7 +8,7 @@ from aws.iam.resources import iam_admin_login_profiles, iam_admin_mfa_devices
 @pytest.mark.parametrize(
     ["iam_login_profile", "iam_user_mfa_devices"],
     zip(iam_admin_login_profiles(), iam_admin_mfa_devices()),
-    ids=get_iam_user_name_only,
+    ids=get_iam_resource_id,
 )
 def test_iam_admin_user_without_mfa(iam_login_profile, iam_user_mfa_devices):
     """Test that all "admin" users with console access also have an MFA device.

--- a/aws/iam/test_iam_user_without_mfa.py
+++ b/aws/iam/test_iam_user_without_mfa.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aws.iam.helpers import get_iam_user_name_only
+from aws.iam.helpers import get_iam_resource_id
 from aws.iam.resources import iam_user_login_profiles, iam_user_mfa_devices
 
 
@@ -8,7 +8,7 @@ from aws.iam.resources import iam_user_login_profiles, iam_user_mfa_devices
 @pytest.mark.parametrize(
     ["iam_login_profile", "iam_user_mfa_devices"],
     zip(iam_user_login_profiles(), iam_user_mfa_devices()),
-    ids=get_iam_user_name_only,
+    ids=get_iam_resource_id,
 )
 def test_iam_user_without_mfa(iam_login_profile, iam_user_mfa_devices):
     """Test that all users with console access also have an MFA device."""

--- a/aws/rds/helpers.py
+++ b/aws/rds/helpers.py
@@ -142,6 +142,24 @@ def get_db_security_group_arn(sg):
     return get_param_id(sg, "DBSecurityGroupArn")
 
 
+def get_rds_resource_id(resource):
+    if isinstance(resource, dict) and "DBInstanceIdentifier" in resource:
+        return get_db_instance_id(resource)
+    if isinstance(resource, dict) and "DBSnapshotArn" in resource:
+        return get_db_snapshot_arn(resource)
+    if isinstance(resource, dict) and "DBSecurityGroupArn" in resource:
+        return get_db_security_group_arn(resource)
+    if isinstance(resource, dict) and "AttributeName" in resource:
+        return get_param_id(resource, "AttributeName")
+
+    if isinstance(resource, list):
+        if len(resource) == 0:
+            return "empty"
+        return get_rds_resource_id(resource[0])
+
+    return None
+
+
 def rds_db_snapshot_not_too_old(snapshot, snapshot_created_days_ago=365):
     """
     Check a rds snapshot is created "snapshot_created_days_ago".

--- a/aws/rds/resources.py
+++ b/aws/rds/resources.py
@@ -75,7 +75,7 @@ def rds_db_snapshots():
     )
 
 
-def rds_db_snapshots_attributes():
+def rds_db_snapshot_attributes():
     "http://botocore.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.describe_db_snapshot_attributes"
     empty_attrs = {"DBSnapshotAttributesResult": {"DBSnapshotAttributes": []}}
     return [

--- a/aws/rds/test_rds_db_instance_not_publicly_accessible_by_vpc_sg.py
+++ b/aws/rds/test_rds_db_instance_not_publicly_accessible_by_vpc_sg.py
@@ -16,7 +16,7 @@ from aws.rds.helpers import (
     zip(rds_db_instances_with_tags(), rds_db_instances_vpc_security_groups()),
     ids=lambda db: get_db_instance_id(db)
     if isinstance(db, dict) and "DBInstanceIdentifier" in db
-    else None,
+    else "secgroups",
 )
 def test_rds_db_instance_not_publicly_accessible_by_vpc_security_group(
     rds_db_instance, ec2_security_groups

--- a/aws/rds/test_rds_db_snapshot_not_publicly_accessible.py
+++ b/aws/rds/test_rds_db_snapshot_not_publicly_accessible.py
@@ -1,14 +1,14 @@
 import pytest
 
-from aws.rds.resources import rds_db_snapshots, rds_db_snapshots_attributes
-from aws.rds.helpers import is_rds_db_snapshot_attr_public_access, get_db_snapshot_arn
+from aws.rds.resources import rds_db_snapshots, rds_db_snapshot_attributes
+from aws.rds.helpers import is_rds_db_snapshot_attr_public_access, get_rds_resource_id
 
 
 @pytest.mark.rds
 @pytest.mark.parametrize(
     ["rds_db_snapshot", "rds_db_snapshot_attributes"],
-    zip(rds_db_snapshots(), rds_db_snapshots_attributes()),
-    ids=get_db_snapshot_arn,
+    zip(rds_db_snapshots(), rds_db_snapshot_attributes()),
+    ids=get_rds_resource_id,
 )
 def test_rds_db_snapshot_not_publicly_accessible(
     rds_db_snapshot, rds_db_snapshot_attributes

--- a/aws/s3/helpers.py
+++ b/aws/s3/helpers.py
@@ -5,7 +5,31 @@ def get_s3_bucket_name(bucket):
     return get_param_id(bucket, "Name")
 
 
-def get_s3_bucket_name_only(bucket):
-    if isinstance(bucket, dict) and "Name" in bucket:
-        return get_s3_bucket_name(bucket)
+def get_s3_resource_id(resource):
+    if isinstance(resource, dict) and "Name" in resource:
+        return get_s3_bucket_name(resource)
+    if isinstance(resource, dict) and "ID" in resource:
+        return get_param_id(resource, "ID")
+    if isinstance(resource, dict) and "Owner" in resource:  # ACL
+        return get_param_id(resource["Owner"], "DisplayName")
+    if isinstance(resource, dict) and "Status" in resource:  # Versioning
+        return get_param_id(resource, "Status")
+    if isinstance(resource, dict) and "AllowedHeaders" in resource:  # CORS
+        return "cors-rules"
+
+    if isinstance(resource, dict) and "ResponseMetadata" in resource:
+        return "empty"
+
+    if isinstance(resource, dict) and not resource:
+        return "empty"
+
+    if isinstance(resource, list):
+        if len(resource) == 0:
+            return "empty"
+        else:
+            return get_s3_resource_id(resource[0])
+
+    if resource is None:
+        return "none"
+
     return None

--- a/aws/s3/test_s3_bucket_cors_disabled.py
+++ b/aws/s3/test_s3_bucket_cors_disabled.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aws.s3.helpers import get_s3_bucket_name_only
+from aws.s3.helpers import get_s3_resource_id
 from aws.s3.resources import s3_buckets, s3_buckets_cors_rules
 
 
@@ -8,7 +8,7 @@ from aws.s3.resources import s3_buckets, s3_buckets_cors_rules
 @pytest.mark.parametrize(
     ["s3_bucket", "s3_bucket_cors_rules"],
     zip(s3_buckets(), s3_buckets_cors_rules()),
-    ids=get_s3_bucket_name_only,
+    ids=get_s3_resource_id,
 )
 def test_s3_bucket_cors_disabled(s3_bucket, s3_bucket_cors_rules):
     """

--- a/aws/s3/test_s3_bucket_does_not_grant_all_principals_all_actions.py
+++ b/aws/s3/test_s3_bucket_does_not_grant_all_principals_all_actions.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from aws.s3.helpers import get_s3_bucket_name_only
+from aws.s3.helpers import get_s3_resource_id
 from aws.s3.resources import s3_buckets, s3_buckets_policy
 
 
@@ -13,7 +13,7 @@ STAR_ACTIONS = ["*", "s3:*", "s3:delete*", "s3:put*", "s3:get*", "s3:list*"]
 @pytest.mark.parametrize(
     ["s3_bucket", "s3_bucket_policy"],
     zip(s3_buckets(), s3_buckets_policy()),
-    ids=get_s3_bucket_name_only,
+    ids=get_s3_resource_id,
 )
 def test_s3_bucket_does_not_grant_all_principals_all_actions(
     s3_bucket, s3_bucket_policy

--- a/aws/s3/test_s3_bucket_has_life_cycle_policy.py
+++ b/aws/s3/test_s3_bucket_has_life_cycle_policy.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aws.s3.helpers import get_s3_bucket_name_only
+from aws.s3.helpers import get_s3_resource_id
 from aws.s3.resources import s3_buckets, s3_bucket_lifecycle_configuration
 
 
@@ -8,7 +8,7 @@ from aws.s3.resources import s3_buckets, s3_bucket_lifecycle_configuration
 @pytest.mark.parametrize(
     ["s3_bucket", "lifecycle_configuration"],
     zip(s3_buckets(), s3_bucket_lifecycle_configuration()),
-    ids=get_s3_bucket_name_only,
+    ids=get_s3_resource_id,
 )
 def test_s3_bucket_has_life_cycle_policy(s3_bucket, lifecycle_configuration):
     """

--- a/aws/s3/test_s3_bucket_logging_enabled.py
+++ b/aws/s3/test_s3_bucket_logging_enabled.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aws.s3.helpers import get_s3_bucket_name
+from aws.s3.helpers import get_s3_resource_id
 from aws.s3.resources import s3_buckets, s3_buckets_logging
 
 
@@ -8,7 +8,7 @@ from aws.s3.resources import s3_buckets, s3_buckets_logging
 @pytest.mark.parametrize(
     ["s3_bucket", "s3_bucket_logging_enabled"],
     zip(s3_buckets(), s3_buckets_logging()),
-    ids=get_s3_bucket_name,
+    ids=get_s3_resource_id,
 )
 def test_s3_bucket_logging_enabled(s3_bucket, s3_bucket_logging_enabled):
     """

--- a/aws/s3/test_s3_bucket_no_world_acl.py
+++ b/aws/s3/test_s3_bucket_no_world_acl.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aws.s3.helpers import get_s3_bucket_name_only
+from aws.s3.helpers import get_s3_resource_id
 from aws.s3.resources import s3_buckets, s3_buckets_acls
 
 
@@ -16,7 +16,7 @@ AWS_PREDEFINED_GROUPS = [
 @pytest.mark.parametrize(
     ["s3_bucket", "s3_bucket_acl"],
     zip(s3_buckets(), s3_buckets_acls()),
-    ids=get_s3_bucket_name_only,
+    ids=get_s3_resource_id,
 )
 def test_s3_bucket_no_world_acl(s3_bucket, s3_bucket_acl):
     """

--- a/aws/s3/test_s3_bucket_versioning_enabled.py
+++ b/aws/s3/test_s3_bucket_versioning_enabled.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aws.s3.helpers import get_s3_bucket_name_only
+from aws.s3.helpers import get_s3_resource_id
 from aws.s3.resources import s3_buckets, s3_buckets_versioning
 
 
@@ -8,7 +8,7 @@ from aws.s3.resources import s3_buckets, s3_buckets_versioning
 @pytest.mark.parametrize(
     ["s3_bucket", "s3_bucket_versioning"],
     zip(s3_buckets(), s3_buckets_versioning()),
-    ids=get_s3_bucket_name_only,
+    ids=get_s3_resource_id,
 )
 def test_s3_bucket_versioning_enabled(s3_bucket, s3_bucket_versioning):
     """

--- a/aws/s3/test_s3_bucket_versioning_mfa_delete_enabled.py
+++ b/aws/s3/test_s3_bucket_versioning_mfa_delete_enabled.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aws.s3.helpers import get_s3_bucket_name_only
+from aws.s3.helpers import get_s3_resource_id
 from aws.s3.resources import s3_buckets, s3_buckets_versioning
 
 
@@ -8,7 +8,7 @@ from aws.s3.resources import s3_buckets, s3_buckets_versioning
 @pytest.mark.parametrize(
     ["s3_bucket", "s3_bucket_versioning"],
     zip(s3_buckets(), s3_buckets_versioning()),
-    ids=get_s3_bucket_name_only,
+    ids=get_s3_resource_id,
 )
 def test_s3_bucket_versioning_mfa_delete_enabled(s3_bucket, s3_bucket_versioning):
     """

--- a/aws/s3/test_s3_bucket_web_hosting_disabled.py
+++ b/aws/s3/test_s3_bucket_web_hosting_disabled.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aws.s3.helpers import get_s3_bucket_name_only
+from aws.s3.helpers import get_s3_resource_id
 from aws.s3.resources import s3_buckets, s3_buckets_website
 
 
@@ -8,7 +8,7 @@ from aws.s3.resources import s3_buckets, s3_buckets_website
 @pytest.mark.parametrize(
     ["s3_bucket", "s3_bucket_website"],
     zip(s3_buckets(), s3_buckets_website()),
-    ids=get_s3_bucket_name_only,
+    ids=get_s3_resource_id,
 )
 def test_s3_bucket_web_hosting_disabled(s3_bucket, s3_bucket_website):
     """


### PR DESCRIPTION
Fixes the `ids` argument in all `parameterize` calls that make use of `zip()` so that the outputted id is actually generated.

Fixes #412