### PR TITLE
Fixes COPY so that frost works as expected

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
             git \
             jq
 
+COPY . /app
 WORKDIR /app
 
-
-COPY frost/* frost/
-COPY * ./
 RUN python setup.py install
 
 USER app


### PR DESCRIPTION
the original `COPY * ./` was actually copying sub-directories rather than the contents of the directory, so we want `COPY . /app`

Fixes #397