### PR TITLE
Add test for subscriptions without topics.

### DIFF
--- a/aws/sns/resources.py
+++ b/aws/sns/resources.py
@@ -1,5 +1,4 @@
 from conftest import botocore_client
-import re
 
 
 def sns_subscriptions():
@@ -22,21 +21,12 @@ def sns_topics():
     )
 
 
-def sns_parent_topic_exists(subscription):
-    "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#subscription"
-    topicArn = ":".join(
-        re.split(":", subscription)[0:6]
-    )  # Naive method of divining topic from subscription
-    try:
-        botocore_client.get(
-            service_name="sns",
-            method_name="get_topic_attributes",
-            call_args=[],
-            call_kwargs={"TopicArn": topicArn},
-        )
-        return True
-    except:
-        return False
+def sns_topic_arns():
+    "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#topic"
+    topicArns = {}
+    for x, y in enumerate(sns_topics()):
+        topicArns[y["TopicArn"]] = 1
+    return topicArns
 
 
 def sns_get_subscription_attrs(subscription):

--- a/aws/sns/resources.py
+++ b/aws/sns/resources.py
@@ -1,4 +1,5 @@
 from conftest import botocore_client
+import re
 
 
 def sns_subscriptions():
@@ -19,6 +20,23 @@ def sns_topics():
         .flatten()
         .values()
     )
+
+
+def sns_parent_topic_exists(subscription):
+    "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#subscription"
+    topicArn = ":".join(
+        re.split(":", subscription)[0:6]
+    )  # Naive method of divining topic from subscription
+    try:
+        botocore_client.get(
+            service_name="sns",
+            method_name="get_topic_attributes",
+            call_args=[],
+            call_kwargs={"TopicArn": topicArn},
+        )
+        return True
+    except:
+        return False
 
 
 def sns_get_subscription_attrs(subscription):

--- a/aws/sns/resources.py
+++ b/aws/sns/resources.py
@@ -1,4 +1,6 @@
+import botocore
 from conftest import botocore_client
+from botocore.errorfactory import ClientError
 
 
 def sns_subscriptions():
@@ -47,8 +49,11 @@ def sns_get_subscription_attrs(subscription):
             .values()[0]
         )
         return attrs
-    except:
-        pass
+    except botocore.errorfactory.ClientError as e:
+        if e.response["Error"]["Code"] != "InvalidParameter":
+            raise
+    # except:
+    #    pass
 
 
 def sns_subscription_attributes():

--- a/aws/sns/resources.py
+++ b/aws/sns/resources.py
@@ -1,6 +1,4 @@
-import botocore
 from conftest import botocore_client
-from botocore.errorfactory import ClientError
 
 
 def sns_subscriptions():
@@ -25,42 +23,7 @@ def sns_topics():
 
 def sns_topic_arns():
     "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#topic"
-    topicArns = {}
-    for x, y in enumerate(sns_topics()):
-        topicArns[y["TopicArn"]] = 1
-    return topicArns
-
-
-def sns_get_subscription_attrs(subscription):
-    "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#subscription"
-    # This function catches the error thrown by the AWS API when attempting to query the attributes of
-    # a subscription that has no parent topic.
-    try:
-        attrs = (
-            botocore_client.get(
-                service_name="sns",
-                method_name="get_subscription_attributes",
-                call_args=[],
-                call_kwargs={"SubscriptionArn": subscription["SubscriptionArn"]},
-                profiles=[subscription["__pytest_meta"]["profile"]],
-                regions=[subscription["__pytest_meta"]["region"]],
-            )
-            .extract_key("Attributes")
-            .values()[0]
-        )
-        return attrs
-    except botocore.errorfactory.ClientError as e:
-        if e.response["Error"]["Code"] != "InvalidParameter":
-            raise
-    # except:
-    #    pass
-
-
-def sns_subscription_attributes():
-    "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#subscription"
-    return [
-        sns_get_subscription_attrs(subscription) for subscription in sns_subscriptions()
-    ]
+    return {x["TopicArn"] for x in sns_topics()}
 
 
 def sns_subscriptions_by_topic():

--- a/aws/sns/resources.py
+++ b/aws/sns/resources.py
@@ -21,20 +21,32 @@ def sns_topics():
     )
 
 
+def sns_get_subscription_attrs(subscription):
+    "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#subscription"
+    # This function catches the error thrown by the AWS API when attempting to query the attributes of
+    # a subscription that has no parent topic.
+    try:
+        attrs = (
+            botocore_client.get(
+                service_name="sns",
+                method_name="get_subscription_attributes",
+                call_args=[],
+                call_kwargs={"SubscriptionArn": subscription["SubscriptionArn"]},
+                profiles=[subscription["__pytest_meta"]["profile"]],
+                regions=[subscription["__pytest_meta"]["region"]],
+            )
+            .extract_key("Attributes")
+            .values()[0]
+        )
+        return attrs
+    except:
+        pass
+
+
 def sns_subscription_attributes():
     "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sns.html#subscription"
     return [
-        botocore_client.get(
-            service_name="sns",
-            method_name="get_subscription_attributes",
-            call_args=[],
-            call_kwargs={"SubscriptionArn": subscription["SubscriptionArn"]},
-            profiles=[subscription["__pytest_meta"]["profile"]],
-            regions=[subscription["__pytest_meta"]["region"]],
-        )
-        .extract_key("Attributes")
-        .values()[0]
-        for subscription in sns_subscriptions()
+        sns_get_subscription_attrs(subscription) for subscription in sns_subscriptions()
     ]
 
 

--- a/aws/sns/test_sns_pending_verified.py
+++ b/aws/sns/test_sns_pending_verified.py
@@ -16,6 +16,6 @@ notifications. They are good candidates for removal, or confirmation.
     sns_subscriptions_by_topic(),
     ids=lambda topic: get_param_id(topic, "TopicArn"),
 )
-def test_sns_topics_without_subscriptions(topic):
+def test_sns_topics_with_subscriptions_pending_confirmation(topic):
     for subscription in topic["Subscriptions"]:
         assert subscription["SubscriptionArn"] != "PendingConfirmation"

--- a/aws/sns/test_sns_pending_verified.py
+++ b/aws/sns/test_sns_pending_verified.py
@@ -1,14 +1,21 @@
 import pytest
 from helpers import get_param_id
 
-from aws.sns.resources import sns_subscription_attributes
+from aws.sns.resources import sns_subscriptions_by_topic
 
 
 @pytest.mark.sns
-@pytest.mark.parametrize(
-    "subscription_attrs",
-    sns_subscription_attributes(),
-    ids=lambda subscription: get_param_id(subscription, "SubscriptionArn"),
+@pytest.mark.rationale(
+    """
+SNS Subscriptions in PendingConfirmation status cannot receive
+notifications. They are good candidates for removal, or confirmation.
+"""
 )
-def test_sns_pending_verified(subscription_attrs):
-    assert subscription_attrs["PendingConfirmation"] == "false"
+@pytest.mark.parametrize(
+    "topic",
+    sns_subscriptions_by_topic(),
+    ids=lambda topic: get_param_id(topic, "TopicArn"),
+)
+def test_sns_topics_without_subscriptions(topic):
+    for subscription in topic["Subscriptions"]:
+        assert subscription["SubscriptionArn"] != "PendingConfirmation"

--- a/aws/sns/test_sns_subscriptions_without_topics.py
+++ b/aws/sns/test_sns_subscriptions_without_topics.py
@@ -2,7 +2,12 @@ import pytest
 from helpers import get_param_id
 
 from aws.sns.resources import sns_subscriptions
-from aws.sns.resources import sns_parent_topic_exists
+from aws.sns.resources import sns_topic_arns
+
+
+@pytest.fixture
+def topics():
+    return sns_topic_arns()
 
 
 @pytest.mark.sns
@@ -17,5 +22,5 @@ receive messages.  They are good candidates for removal.
     sns_subscriptions(),
     ids=lambda subscription: get_param_id(subscription, "SubscriptionArn"),
 )
-def test_sns_subscriptions_without_parent_topics(subscription):
-    assert sns_parent_topic_exists(subscription["SubscriptionArn"])
+def test_sns_subscriptions_without_parent_topics(subscription, topics):
+    assert topics[subscription["TopicArn"]] == 1

--- a/aws/sns/test_sns_subscriptions_without_topics.py
+++ b/aws/sns/test_sns_subscriptions_without_topics.py
@@ -23,4 +23,4 @@ receive messages.  They are good candidates for removal.
     ids=lambda subscription: get_param_id(subscription, "SubscriptionArn"),
 )
 def test_sns_subscriptions_without_parent_topics(subscription, topics):
-    assert topics[subscription["TopicArn"]] == 1
+    assert subscription["TopicArn"] in topics

--- a/aws/sns/test_sns_subscriptions_without_topics.py
+++ b/aws/sns/test_sns_subscriptions_without_topics.py
@@ -1,0 +1,21 @@
+import pytest
+from helpers import get_param_id
+
+from aws.sns.resources import sns_subscriptions
+from aws.sns.resources import sns_parent_topic_exists
+
+
+@pytest.mark.sns
+@pytest.mark.rationale(
+    """
+SNS subscriptions subscribed to non-existent topics cannot
+receive messages.  They are good candidates for removal.
+"""
+)
+@pytest.mark.parametrize(
+    "subscription",
+    sns_subscriptions(),
+    ids=lambda subscription: get_param_id(subscription, "SubscriptionArn"),
+)
+def test_sns_subscriptions_without_parent_topics(subscription):
+    assert sns_parent_topic_exists(subscription["SubscriptionArn"])


### PR DESCRIPTION
This PR intends to do two things:

1. Stop the `sns_subscription_attributes()` function from crashing the **test_sns_pending_verified.py** test when the AWS API throws an error on getting attributes for a subscription that does not have a parent topic.
1. Add a test to find subscriptions that have no parent topic.

It works as is, but there are few things that need fixing before a merge.

- The method used to truncate an SNS subscription ARN into an SNS topic ARN is not great:
```
topic = ':'.join(re.split(':', s_arn)[0:6])
```
- Several functions added might be moved into an SNS **helpers.py** file instead of their current location in **resources.py**.
  - `sns_parent_topic_exists()`
  - `sns_get_subscription_attrs()`

No doubt there are other pythonic issues.