### PR TITLE
add GHA CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,6 +68,7 @@ jobs:
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_REPOSITORY_URL: https://test.pypi.org/
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,73 @@
+# Upload a Python Package using Twine when a semver tag is pushed to
+# the default branch
+#
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  push:
+    branches:
+      - master
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - '[0-9]+\.[0-9]+\.[0-9]+'
+
+jobs:
+  publish-gh-pages:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install doc dependencies in venv
+      run: |
+        make install-docs
+
+    - name: build docs
+      shell: bash
+      run: |
+        make doc-build
+
+    - name: publish docs to GH pages
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: |
+        mv docs/_build/html/ .
+        git add .
+        git commit -vm 'build docs for gh-page'
+        git push -f origin HEAD:gh-pages
+
+  publish-package:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install publish dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Install package dependencies
+      run: |
+        pip install -r requirements.txt
+
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Test
+
+on: [push, pull_request]
+
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8]
+        os: [ubuntu-latest, ubuntu-20.04]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          make install install-docs
+
+      - name: Run Tests
+        shell: bash
+        run: |
+          (source venv/bin/activate && make black check_conftest_imports doctest coverage doc-build)


### PR DESCRIPTION
refs: #429

Migrate CI to github actions

NB: test w/ python 3.9 fails due to a dep build failure, but I think that's fine for now and we can not require it to pass to merge

NB: there are third party actions for publish GH pages we could try too (pending GH admin approval)

I don't have a way to test the publish actions. I'm least certain about the `gh-pages` action in particular.

- [ ] generate and add new pypi creds to the workflow config
- [ ] generate and add a new GH token with repo scope to the workflow config
- [ ] update the required jobs in branch protection settings
- [ ] tag a commit to test the publish workflow
- [ ] remove the travis CI config; update badges (separate PR)

r? @ajvb @hwine 