### PR TITLE
ci: GHA clone with ssh deploy key

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        ssh-key: ${{ secrets.DEPLOY_KEY }}
 
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -35,11 +37,9 @@ jobs:
         make doc-build
 
     - name: publish docs to GH pages
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: bash
       run: |
-        mv docs/_build/html/ .
+        mv -f docs/_build/html/* .
         git add .
         git commit -vm 'build docs for gh-page'
         git push -f origin HEAD:gh-pages


### PR DESCRIPTION
refs: #432

Two things:

* secrets with the `GITHUB_` are reserved, so I couldn't add `GITHUB_TOKEN`
* a new deploy key (with access limited to this repo; and accessible to any repo admin) seemed cleaner than generate a new repo scope oauth token, so I went that route

Next steps:

- [ ] tag a commit to test the publish workflow
- [ ] remove the travis CI config; update badges (separate PR); switch publish config to use the prod pypi repo url